### PR TITLE
mantis: add SQLi and SSRF sinks to source-sink heuristic

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -79,6 +79,29 @@ const RULES = [
     pattern: /\b(node-serialize|serialize\.unserialize)\s*\(/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.sql.query_template_literal",
+    pattern: /\.(query|execute)\s*\(\s*`[^`]*\$\{/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.sql.query_string_concat",
+    pattern:
+      /\.(query|execute)\s*\(\s*(['"][^'"]*['"]\s*\+|[A-Za-z_$][\w$]*\s*\+\s*['"])/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.ssrf.dynamic_url",
+    pattern:
+      /\b(axios(\.\w+)?|fetch|got)\s*\(\s*(`[^`]*\$\{|[A-Za-z_$][\w$.]*\s*\+\s*)/g,
+    cwe: "CWE-918",
+  },
 
   // Python
   {
@@ -129,6 +152,28 @@ const RULES = [
     pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_fstring",
+    pattern: /\.execute\s*\(\s*f["']/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_format_concat",
+    pattern: /\.execute\s*\(\s*["'][^"']*["']\s*(%|\.format\s*\(|\+)/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.ssrf.dynamic_url",
+    pattern:
+      /\brequests\.(get|post|put|delete|patch|head|request)\s*\(\s*(f["']|[A-Za-z_][\w]*\s*\+|["'][^"']*["']\s*(%|\.format\s*\())/g,
+    cwe: "CWE-918",
+  },
 
   // Go
   {
@@ -151,6 +196,22 @@ const RULES = [
     id: "go.template.html",
     pattern: /\btemplate\.HTML\s*\(/g,
     cwe: "CWE-79",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.sql.query_sprintf",
+    pattern:
+      /\.(Query|QueryRow|QueryContext|Exec|ExecContext)\s*\(\s*fmt\.Sprintf/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.ssrf.dynamic_url",
+    pattern:
+      /\bhttp\.(Get|Post|NewRequest|NewRequestWithContext)\s*\(\s*(fmt\.Sprintf|[A-Za-z_]\w*\s*\+)/g,
+    cwe: "CWE-918",
   },
 
   // Java


### PR DESCRIPTION
## What gap this closes

`.codex/agents/recon.toml` explicitly instructs the Recon agent to treat "SQL/NoSQL query construction" and "HTTP client calls (SSRF)" as sinks of interest. But the actual heuristic source/sink tagger that feeds Recon/Detect (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) had:

- **Zero SQL-injection sink patterns** for JS, Python, or Go — only Java (`statement.execute`) was covered.
- **Zero SSRF sink patterns** for any language at all.

That's a real mismatch between what the pipeline's own docs say it looks for and what the tool could actually flag — a coverage gap for two of the vulnerability classes this run's scan is specifically asked to check for (SQL injection is named directly).

## What changed

Added sink rules (all CWE-tagged, `kind: "sink"`, additive only — no existing rules touched):

- **SQLi**: `js.sql.query_template_literal`, `js.sql.query_string_concat`, `py.sql.execute_fstring`, `py.sql.execute_format_concat`, `go.sql.query_sprintf` (CWE-89)
- **SSRF**: `js.ssrf.dynamic_url`, `py.ssrf.dynamic_url`, `go.ssrf.dynamic_url` (CWE-918)

Patterns are scoped to the *dynamic construction* case (template-literal interpolation, string concatenation, `%`-format, `f`-strings, `fmt.Sprintf`) so parameterized queries (`db.query("... WHERE id = ?", [id])`) and static URLs (`fetch("https://api.example.com/health")`) are **not** flagged — keeping the recall gain from inflating false positives, consistent with this heuristic's "detect generous, but don't manufacture noise" role feeding the ruthless Validate stage downstream.

## Testing

No existing test harness covers this pure-data rules file. Verified manually:
- `node --check` passes (syntax).
- Ran the new + existing rules against 15 hand-written snippets (vulnerable and safe variants of each new pattern, across JS/Python/Go) — all matched or correctly did not match as expected.
- Ran the full `source_sink_rules.js` against a small sample Flask handler containing an f-string SQL query and an f-string SSRF call — both new sinks fired with correct line/CWE attribution, alongside the existing `py.flask.request` source detections.
- `prettier --check`/`--write` applied to match repo formatting conventions.


---
_Generated by [Claude Code](https://claude.ai/code/session_0114JYpExynyBDxWaNGxYTRH)_