### PR TITLE
fix: close reachability-gate bypass in finding_update confirm

### DIFF
--- a/.codex/mcp-servers/findings/server.js
+++ b/.codex/mcp-servers/findings/server.js
@@ -218,9 +218,17 @@ function findingUpdate(args) {
       );
     }
     if (status === "confirmed") {
+      // NOTE: `reasoning_trace_ref` is deliberately excluded here. It is set
+      // at `finding_create` time as a pointer to the *detection* reasoning
+      // (why this candidate was flagged), not proof that attacker input
+      // reaches the sink. Since the detector attaches it to most/all
+      // candidates, treating it as reachability evidence let almost any
+      // finding satisfy this gate on its first confirm attempt, defeating
+      // the "no confirmed without reachability evidence" invariant (PRD
+      // section 5/8, findings-spine skill: only `reachability_note` or
+      // attached `evidence` count).
       const hasReach =
         args.reachability_note ||
-        existing.reasoning_trace_ref ||
         (Array.isArray(existing.evidence) && existing.evidence.length > 0) ||
         (Array.isArray(evidence) && evidence.length > 0);
       if (!hasReach) {

--- a/.codex/mcp-servers/findings/server.test.js
+++ b/.codex/mcp-servers/findings/server.test.js
@@ -1,0 +1,87 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+// findings/server.js starts an MCP stdio server as a side effect of being
+// required and resolves its data dir relative to __dirname, so it can't be
+// require()'d directly in a unit test. This harness writes a patched copy
+// next to the real file (so its `require("../lib/mcp_stdio.js")` still
+// resolves), pointed at a throwaway data dir instead of the real (gitignored)
+// .codex/findings/ event log, with the createServer() call stripped so
+// loading it doesn't start a stdio server and hang the test process.
+const SERVER_PATH = path.join(__dirname, "server.js");
+
+function loadServerWithTempDataDir() {
+  const tmpDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "mantis-findings-"));
+  const src = fs.readFileSync(SERVER_PATH, "utf8");
+  const patched = src
+    .replace(
+      'const DATA_DIR = path.join(__dirname, "..", "..", "findings");',
+      `const DATA_DIR = ${JSON.stringify(tmpDataDir)};`,
+    )
+    .replace(/createServer\(\{[\s\S]*\}\);\s*$/, "");
+  const modPath = path.join(
+    __dirname,
+    `.server_under_test.${crypto.randomBytes(6).toString("hex")}.js`,
+  );
+  fs.writeFileSync(
+    modPath,
+    patched +
+      "\nmodule.exports = { findingCreate, findingUpdate, findingGet, findingList };\n",
+  );
+  try {
+    return require(modPath);
+  } finally {
+    fs.unlinkSync(modPath);
+  }
+}
+
+test("confirming with only a reasoning_trace_ref (no reachability_note/evidence) is refused", () => {
+  const { findingCreate, findingUpdate } = loadServerWithTempDataDir();
+  const created = findingCreate({
+    vuln_class: "sql-injection",
+    claim: "unsanitized query built from request.args",
+    reasoning_trace_ref: "trace-123",
+  });
+  assert.equal(created.status, "candidate");
+
+  assert.throws(
+    () => findingUpdate({ id: created.id, status: "confirmed" }),
+    /requires reachability\/attack-simulation evidence/,
+  );
+});
+
+test("confirming with a reachability_note succeeds", () => {
+  const { findingCreate, findingUpdate } = loadServerWithTempDataDir();
+  const created = findingCreate({
+    vuln_class: "sql-injection",
+    claim: "unsanitized query built from request.args",
+  });
+
+  const updated = findingUpdate({
+    id: created.id,
+    status: "confirmed",
+    reachability_note: "traced request.args.id into raw SQL string concat",
+  });
+  assert.equal(updated.status, "confirmed");
+});
+
+test("confirming with attached evidence succeeds", () => {
+  const { findingCreate, findingUpdate } = loadServerWithTempDataDir();
+  const created = findingCreate({
+    vuln_class: "xss",
+    claim: "reflected param written to innerHTML",
+  });
+
+  const updated = findingUpdate({
+    id: created.id,
+    status: "confirmed",
+    evidence: [{ request_ref: "req-abc123" }],
+  });
+  assert.equal(updated.status, "confirmed");
+});


### PR DESCRIPTION
## What gap this closes

The findings-spine invariant repeated across `.codex/MANTIS.md`, `.codex/skills/mantis-pipeline/SKILL.md`, and `.codex/skills/findings-spine/SKILL.md` is: **"no `confirmed` without reachability evidence"** — a finding can only move `candidate -> confirmed` after attacker-simulation proves the sink is reachable, via `reachability_note` or attached `evidence`.

`findingUpdate`'s enforcement of that gate (`.codex/mcp-servers/findings/server.js`) also accepted a truthy `existing.reasoning_trace_ref` as proof:

```js
const hasReach =
  args.reachability_note ||
  existing.reasoning_trace_ref ||          // <-- the bug
  (Array.isArray(existing.evidence) && existing.evidence.length > 0) ||
  (Array.isArray(evidence) && evidence.length > 0);
```

But `reasoning_trace_ref` is documented on `finding_create` as just "Reference to the reasoning trace for this candidate" — a pointer to *why Detect flagged it*, not proof that attacker-controlled input reaches the sink. Since the detector is expected to attach a reasoning trace ref to most/all candidates it creates, this let almost any `candidate` finding satisfy the confirm gate on the very first attempt, with zero reachability tracing or attacker-simulation — silently defeating the "Validate is ruthless" discipline the whole pipeline is designed around (a false-negative in the gate that's supposed to catch weak findings, i.e. it let unproven findings through as if they were proven).

This directly affects report quality and severity accuracy downstream: `finding_list`/the `reporter` agent treat `confirmed` as meaning "attacker-simulated," so a confirm that only ever checked for the presence of a reasoning pointer could surface unproven candidates as if they were validated.

## What changed

- Removed `existing.reasoning_trace_ref` from the `hasReach` check in `finding_update`'s confirm path. Confirming now requires an actual `reachability_note` or attached `evidence`, matching what the `findings-spine` skill already documents as the intended behavior.
- Added `.codex/mcp-servers/findings/server.test.js` (Node's built-in `node:test`, zero new deps): loads a patched copy of `server.js` pointed at a throwaway temp data dir (so tests never touch the real gitignored `.codex/findings/` event log) and covers:
  - a finding created with only `reasoning_trace_ref` is **refused** on confirm (the regression case — fails against the pre-fix code, verified locally by stashing the fix and re-running)
  - confirming with `reachability_note` succeeds
  - confirming with attached `evidence` succeeds

## Testing

```
node --check .codex/mcp-servers/findings/server.js
node --check .codex/mcp-servers/findings/server.test.js
node --test .codex/mcp-servers/findings/server.test.js
# 3 pass, 0 fail

npx prettier --check .codex/mcp-servers/findings/server.js .codex/mcp-servers/findings/server.test.js
# All matched files use Prettier code style!
```

Also confirmed the new test fails (1 fail) when run against the pre-fix `server.js` via `git stash`, to make sure it actually catches the regression rather than passing vacuously.

## Scope

Small and focused: no new MCP tools, no change to the `finding_create`/`finding_update` public input schema — only the confirm-gate's evidence check is tightened to match the already-documented invariant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJRho3JZJBmZukWpkUVm51)_