### PR TITLE
mantis: add XSS/SSTI sinks for Python and Java to source-sink heuristic

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -129,6 +129,20 @@ const RULES = [
     pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.django.mark_safe",
+    pattern: /\bmark_safe\s*\(/g,
+    cwe: "CWE-79",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.flask.render_template_string",
+    pattern: /\brender_template_string\s*\(/g,
+    cwe: "CWE-1336",
+  },
 
   // Go
   {
@@ -187,6 +201,13 @@ const RULES = [
     id: "java.statement.execute",
     pattern: /\bstatement\.execute(Query|Update)?\s*\(/gi,
     cwe: "CWE-89",
+  },
+  {
+    lang: "java",
+    kind: "sink",
+    id: "java.servlet.writer_output",
+    pattern: /\bresponse\.getWriter\(\)\.(print|println)\s*\(/g,
+    cwe: "CWE-79",
   },
 ];
 

--- a/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { RULES } = require("./source_sink_rules.js");
+
+function matches(id, text) {
+  const rule = RULES.find((r) => r.id === id);
+  assert.ok(rule, `no rule registered with id ${id}`);
+  rule.pattern.lastIndex = 0;
+  return rule.pattern.test(text);
+}
+
+test("py.django.mark_safe flags mark_safe(...) calls", () => {
+  assert.equal(
+    matches("py.django.mark_safe", "return mark_safe(user_bio)"),
+    true,
+  );
+});
+
+test("py.django.mark_safe does not flag unrelated safe_* helpers", () => {
+  assert.equal(
+    matches("py.django.mark_safe", "value = safe_lookup(user_bio)"),
+    false,
+  );
+});
+
+test("py.flask.render_template_string flags dynamic template rendering", () => {
+  assert.equal(
+    matches(
+      "py.flask.render_template_string",
+      'return render_template_string(f"Hello {name}")',
+    ),
+    true,
+  );
+});
+
+test("py.flask.render_template_string does not flag render_template (file-based, no injection surface)", () => {
+  assert.equal(
+    matches(
+      "py.flask.render_template_string",
+      'return render_template("hello.html", name=name)',
+    ),
+    false,
+  );
+});
+
+test("java.servlet.writer_output flags response.getWriter().print/println", () => {
+  assert.equal(
+    matches(
+      "java.servlet.writer_output",
+      'response.getWriter().println(request.getParameter("name"));',
+    ),
+    true,
+  );
+  assert.equal(
+    matches(
+      "java.servlet.writer_output",
+      "response.getWriter().print(safeValue);",
+    ),
+    true,
+  );
+});
+
+test("java.servlet.writer_output does not flag unrelated writer variables", () => {
+  assert.equal(
+    matches("java.servlet.writer_output", "logWriter.println(status);"),
+    false,
+  );
+});
+
+test("every rule id is unique", () => {
+  const ids = RULES.map((r) => r.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test("every sink rule carries a CWE tag", () => {
+  for (const rule of RULES.filter((r) => r.kind === "sink")) {
+    assert.ok(rule.cwe, `sink rule ${rule.id} is missing a cwe tag`);
+  }
+});


### PR DESCRIPTION
## What gap this closes

`.codex/agents/recon.toml` lists "template rendering" alongside exec/eval, SQL construction, and SSRF as a sink class Recon should map. The JS and Go rule sets in `.codex/mcp-servers/program-analysis/source_sink_rules.js` already tag output-escaping-bypass sinks (`js.dom.innerhtml`, `js.react.dangerously_set_inner_html`, `js.document.write`, `go.template.html`), but the Python and Java rule sets had **zero XSS/SSTI sink patterns** — only injection/deserialization sinks. That's a real coverage gap for one of the vulnerability classes this tool is specifically asked to check for (XSS is named directly in the routine's scan scope), on two of the four supported languages.

## What changed

Added three sink rules (additive only, no existing rules touched):

- `py.django.mark_safe` (CWE-79) — `mark_safe(...)` explicitly opts a string out of Django's autoescaping; any call site with attacker-influenced input is a direct XSS sink.
- `py.flask.render_template_string` (CWE-1336) — rendering a dynamically-built Jinja2 template string (vs. a static template file via `render_template`) is the classic Flask SSTI/XSS vector.
- `java.servlet.writer_output` (CWE-79) — `response.getWriter().print/println(...)` writes directly to the HTTP response body, the standard raw-Servlet XSS sink (no auto-escaping like a JSP/templating layer would provide).

## Testing

Added `.codex/mcp-servers/program-analysis/source_sink_rules.test.js` (Node's built-in `node:test`, zero new deps, first automated test coverage for this previously test-free rules file):

```
node --test .codex/mcp-servers/program-analysis/source_sink_rules.test.js
# 8 pass, 0 fail
```

Covers: each new rule firing on a vulnerable snippet, each new rule *not* firing on an adjacent safe/unrelated call (`safe_lookup(...)`, `render_template(...)`, `logWriter.println(...)`), rule-id uniqueness, and that every sink rule carries a CWE tag.

Also manually ran the rule set against hand-written vulnerable `app.py` (Flask `render_template_string(f"...")` + Django `mark_safe(...)`) and `Servlet.java` (`response.getWriter().println("..." + name)`) samples — all three new sinks fired with correct file/line/CWE attribution.

```
node --check .codex/mcp-servers/program-analysis/source_sink_rules.js
node --check .codex/mcp-servers/program-analysis/source_sink_rules.test.js
npx prettier --check .codex/mcp-servers/program-analysis/source_sink_rules.js .codex/mcp-servers/program-analysis/source_sink_rules.test.js
# All matched files use Prettier code style!
```

## Scope

Small and focused: no new MCP tools, no schema changes to `source_sink_scan`'s public input/output shape — only three additive sink patterns plus their tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjpjm1uX3m9WwhPjpoxz26)_