### PR TITLE
fix: stop js.child_process.exec sink from firing on RegExp.exec()

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -48,7 +48,13 @@ const RULES = [
     lang: "js",
     kind: "sink",
     id: "js.child_process.exec",
-    pattern: /\b(child_process\.)?(exec|execSync)\s*\(/g,
+    // Scoped to an explicit child_process-style receiver, or a bare
+    // (non-member) call -- NOT preceded by a `.`. Without the dot exclusion
+    // this matched RegExp.prototype.exec()/Array.prototype.find(...).exec(),
+    // one of the most common JS idioms, flagging nearly every regex match as
+    // an OS command injection sink.
+    pattern:
+      /\b(?:child_process|cp|childProcess)\.(?:exec|execSync)\s*\(|require\(\s*["']child_process["']\s*\)\.(?:exec|execSync)\s*\(|(?<!\.)\b(?:exec|execSync)\s*\(/g,
     cwe: "CWE-78",
   },
   {

--- a/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { RULES } = require("./source_sink_rules.js");
+
+function rule(id) {
+  const found = RULES.find((r) => r.id === id);
+  assert.ok(found, `rule ${id} not found`);
+  return found;
+}
+
+function matches(r, text) {
+  r.pattern.lastIndex = 0;
+  return r.pattern.test(text);
+}
+
+test("js.child_process.exec fires on real child_process calls", () => {
+  const r = rule("js.child_process.exec");
+  assert.equal(matches(r, "child_process.exec(cmd)"), true);
+  assert.equal(matches(r, "cp.execSync(cmd)"), true);
+  assert.equal(matches(r, "childProcess.exec(cmd)"), true);
+  assert.equal(matches(r, "exec(cmd)"), true);
+  assert.equal(matches(r, "execSync(cmd)"), true);
+  assert.equal(matches(r, 'require("child_process").exec(cmd)'), true);
+  assert.equal(matches(r, "require('child_process').execSync(cmd)"), true);
+});
+
+test("js.child_process.exec does not fire on RegExp/Array .exec() member calls", () => {
+  const r = rule("js.child_process.exec");
+  assert.equal(matches(r, "const m = pattern.exec(str);"), false);
+  assert.equal(matches(r, "if (re.exec(line)) { }"), false);
+  assert.equal(matches(r, "arr.filter(x => x.exec(y))"), false);
+  assert.equal(matches(r, "const ok = /foo/.exec(input);"), false);
+});
+
+test("every rule has a unique id", () => {
+  const ids = RULES.map((r) => r.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test("every sink rule carries a CWE tag", () => {
+  for (const r of RULES.filter((r) => r.kind === "sink")) {
+    assert.ok(r.cwe, `sink rule ${r.id} is missing a cwe tag`);
+  }
+});


### PR DESCRIPTION
## What gap this closes

`source_sink_scan` (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) is the heuristic recall tool the `recon`/`detector` agents use to widen the candidate list before reachability tracing (see `mantis-pipeline`/`program-analysis` skills). Its `js.child_process.exec` sink rule (CWE-78, OS command injection) was:

```js
pattern: /\b(child_process\.)?(exec|execSync)\s*\(/g,
```

The `\b` boundary doesn't exclude a preceding `.`, so this matches **any** member call named `exec`/`execSync`, not just `child_process.exec()`. `RegExp.prototype.exec()` — one of the most common JS/TS idioms for regex matching (`pattern.exec(str)`, `re.exec(line)`, `/foo/.exec(input)`) — fired this CWE-78 sink every single time. Verified against current `main`:

```
node -e '...'
"child_process.exec(cmd)" -> true   (correct)
"const m = pattern.exec(str);" -> true   (false positive)
"if (re.exec(line)) { ... }" -> true      (false positive)
"arr.filter(x => x.exec(y))" -> true      (false positive)
```

This is a real false-positive-rate problem, not a cosmetic one: `source_sink_scan` runs early in Recon/Detect specifically to widen candidates cheaply, and per the pipeline's own "detect generous, but don't manufacture noise" discipline (see PR history on this file), a sink that fires on nearly every regex-validation call site buries genuine command-injection sinks in noise and wastes Validate-stage attacker-simulation effort chasing regex matches.

This is a different fix from the several currently-open detection-breadth PRs on this file (#101 SQLi/SSRF, #103 XSS/SSTI, #104 SQLi driver calls, #108 path traversal) — those add new additive sink patterns; this one narrows an existing, already-shipped rule to remove a false-positive source, and touches no rule those PRs added.

## What changed

Scoped the `js.child_process.exec` pattern to only match:
- `child_process.exec(...)` / `cp.exec(...)` / `childProcess.exec(...)` (and `execSync` variants)
- `require("child_process").exec(...)` / `require('child_process').execSync(...)`
- a bare, non-member call: `exec(...)` / `execSync(...)` not preceded by a `.`

...and explicitly excludes any other dot-prefixed member call (`pattern.exec(...)`, `re.exec(...)`, etc.).

Added `.codex/mcp-servers/program-analysis/source_sink_rules.test.js` — first automated test coverage for this previously test-free rules file (Node's built-in `node:test`, zero new deps). Covers:
- the fix: `pattern.exec()`/`re.exec()`/`x.exec()`/`/foo/.exec()` no longer match
- the fix doesn't regress real detection: `child_process.exec/execSync`, `cp.exec`, `childProcess.exec`, bare `exec()`/`execSync()`, and both `require("child_process").exec(...)` forms still match
- rule-id uniqueness across the whole table
- every `kind: "sink"` rule carries a CWE tag

## Testing

```
node --check .codex/mcp-servers/program-analysis/source_sink_rules.js
node --check .codex/mcp-servers/program-analysis/source_sink_rules.test.js
node --test .codex/mcp-servers/program-analysis/source_sink_rules.test.js
# 4 pass, 0 fail

npx prettier --check .codex/mcp-servers/program-analysis/source_sink_rules.js .codex/mcp-servers/program-analysis/source_sink_rules.test.js
# All matched files use Prettier code style!
```

## Scope

Small and focused: no new MCP tools, no schema change to `source_sink_scan`'s public input/output shape, no other rules touched — only the one over-broad pattern is narrowed, plus its new test file.

## Scan report (task 2 of this routine)

Could not run the discovery scan this cycle: the environment's own egress proxy denied the authorized target host at the policy layer again (`gateway answered 403 to CONNECT (policy denial or upstream failure)`, host `vulnerable-bounty-site.vercel.app:443`, per `$HTTPS_PROXY/__agentproxy/status`), and an independent `WebFetch` attempt to the same host also returned a 403 with no body. This is the same failure mode reported in PR #108's routine run. Per the environment's proxy guidance, policy denials are reported rather than retried/routed around, so no scan was performed and no findings are reported this run.

---
_Generated by a scheduled Claude Code maintenance routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01AymZkzYFH1PqUnMwWpARFs)_