### PR TITLE
fix: stop js.dom.innerhtml sink from firing on equality comparisons

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -55,7 +55,11 @@ const RULES = [
     lang: "js",
     kind: "sink",
     id: "js.dom.innerhtml",
-    pattern: /\b(innerHTML|outerHTML)\s*=/g,
+    // Requires an assignment operator (`=` or `+=`), not just any `=`-bearing
+    // token -- a bare trailing `=` also matches the first `=` of `==`/`===`/
+    // `!==`, so `if (el.innerHTML === safe)` was flagging every equality
+    // comparison against innerHTML/outerHTML as a write sink.
+    pattern: /\b(innerHTML|outerHTML)\s*(\+=|=(?!=))/g,
     cwe: "CWE-79",
   },
   {

--- a/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { RULES } = require("./source_sink_rules.js");
+
+function rule(id) {
+  const found = RULES.find((r) => r.id === id);
+  assert.ok(found, `rule ${id} not found`);
+  return found;
+}
+
+function matches(r, text) {
+  r.pattern.lastIndex = 0;
+  return r.pattern.test(text);
+}
+
+test("js.dom.innerhtml fires on real assignment sinks", () => {
+  const r = rule("js.dom.innerhtml");
+  assert.equal(matches(r, "el.innerHTML = userInput;"), true);
+  assert.equal(matches(r, "el.outerHTML = userInput;"), true);
+  assert.equal(matches(r, "el.innerHTML += extra;"), true);
+  assert.equal(matches(r, "  node.innerHTML=payload"), true);
+});
+
+test("js.dom.innerhtml does not fire on equality comparisons", () => {
+  const r = rule("js.dom.innerhtml");
+  assert.equal(matches(r, 'if (el.innerHTML == "") { }'), false);
+  assert.equal(matches(r, "if (el.innerHTML === safe) { }"), false);
+  assert.equal(matches(r, "if (el.outerHTML !== previous) { }"), false);
+  assert.equal(matches(r, "assert.equal(el.innerHTML, expected);"), false);
+});
+
+test("every rule has a unique id", () => {
+  const ids = RULES.map((r) => r.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test("every sink rule carries a CWE tag", () => {
+  for (const r of RULES.filter((r) => r.kind === "sink")) {
+    assert.ok(r.cwe, `sink rule ${r.id} is missing a cwe tag`);
+  }
+});


### PR DESCRIPTION
## What gap this closes

`source_sink_scan` (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) is the heuristic recall tool the `recon`/`detector` agents use to widen the candidate list before reachability tracing (see the `mantis-pipeline`/`program-analysis` skills). Its `js.dom.innerhtml` sink rule (CWE-79, DOM XSS) was:

```js
pattern: /\b(innerHTML|outerHTML)\s*=/g,
```

A bare trailing `=` also matches the first `=` of `==`, `===`, and (via the `!` before it not being consumed) effectively any equality/inequality check against `innerHTML`/`outerHTML`. So an ordinary read-only comparison like:

```js
if (el.innerHTML === safeValue) { ... }
assert.equal(el.innerHTML, expected);
```

was flagged as a write sink, identically to a real assignment like `el.innerHTML = userInput`. Verified against current `main`:

```
"el.innerHTML = userInput"        -> true   (correct, real sink)
'if (el.innerHTML == "") {}'      -> true   (false positive)
"if (el.innerHTML === safe) {}"   -> true   (false positive)
```

This is a recall-vs-noise problem, not cosmetic: `source_sink_scan` runs early in Recon/Detect specifically to widen candidates cheaply, and per the pipeline's "detect generous, but don't manufacture noise" discipline, a sink that fires on every equality check against `innerHTML` (a very common pattern in tests and conditionals) buries genuine DOM-XSS write sinks in false positives and wastes Validate-stage attacker-simulation effort.

This is a different rule from the currently open detection-breadth PRs on this file (#101 SQLi/SSRF, #103 XSS/SSTI py/java, #104 SQLi driver calls, #108 path traversal, #109 `child_process.exec`/`RegExp.exec()`) — none of them touch `js.dom.innerhtml`.

## What changed

Narrowed the pattern to require a real assignment operator — `=` not followed by another `=` (excludes `==`/`===`/`!==`), or `+=` — instead of any trailing `=`:

```js
pattern: /\b(innerHTML|outerHTML)\s*(\+=|=(?!=))/g,
```

Added `.codex/mcp-servers/program-analysis/source_sink_rules.test.js` (Node's built-in `node:test`, zero new deps — this rules file had no test coverage before). Covers:
- the fix: `==`/`===`/`!==` comparisons against `innerHTML`/`outerHTML` no longer match
- the fix doesn't regress real detection: plain `=` and `+=` assignments still match
- rule-id uniqueness across the whole table
- every `kind: "sink"` rule carries a CWE tag

## Testing

```
node --check .codex/mcp-servers/program-analysis/source_sink_rules.js
node --check .codex/mcp-servers/program-analysis/source_sink_rules.test.js
node --test .codex/mcp-servers/program-analysis/source_sink_rules.test.js
# 4 pass, 0 fail
```

## Scope

Small and focused: no new MCP tools, no schema change to `source_sink_scan`'s public input/output shape, only the one over-broad pattern is narrowed, plus its new test file.

## Scan report (task 2 of this routine)

Could not run the discovery scan against the authorized target this cycle either: the environment's egress proxy denies `vulnerable-bounty-site.vercel.app:443` at the organization policy layer (`403` on `CONNECT`, confirmed via both a direct `curl` through `$HTTPS_PROXY` and an independent `WebFetch` call — both `403`, no body). Per `/root/.ccr/README.md`, a proxy `403` is a policy denial to report, not something to retry or route around.

This is now the **third consecutive routine run** hitting this exact block (see PR #108 and PR #109's scan-report sections). Since real read-only, discovery-only access to the authorized target has never succeeded across these runs, the target is effectively unreachable from this environment as currently configured — worth the repo owner adding `vulnerable-bounty-site.vercel.app` to the session's egress allowlist if scans against it are meant to actually run.

---
_Generated by a scheduled Claude Code maintenance routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnLi8TRz8Tx8FPks4T5ZZT)_