### PR TITLE
fix: stop py.yaml.load_unsafe false-flagging multiline SafeLoader calls

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -126,7 +126,14 @@ const RULES = [
     lang: "py",
     kind: "sink",
     id: "py.yaml.load_unsafe",
-    pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
+    // The lookahead is bounded to `[^)]*` (not `.*`) so it (a) sees a
+    // `Loader=yaml.SafeLoader` kwarg that lands on a later line of a
+    // multi-line call -- `.` never matches `\n` without the `s` flag, which
+    // was silently defeating this rule's own exemption on wrapped calls --
+    // and (b) still stops at this call's own closing paren instead of
+    // reading into a *different*, later `yaml.load(...)` call the way an
+    // unbounded dotall `[\s\S]*` lookahead would.
+    pattern: /\byaml\.load\s*\((?![^)]*Loader=yaml\.SafeLoader)/g,
     cwe: "CWE-502",
   },
 

--- a/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.test.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { RULES } = require("./source_sink_rules.js");
+
+function matches(ruleId, code) {
+  const rule = RULES.find((r) => r.id === ruleId);
+  assert.ok(rule, `no rule registered with id ${ruleId}`);
+  rule.pattern.lastIndex = 0;
+  return rule.pattern.test(code);
+}
+
+test("py.yaml.load_unsafe flags a bare yaml.load with no Loader", () => {
+  assert.equal(matches("py.yaml.load_unsafe", "yaml.load(user_input)"), true);
+});
+
+test("py.yaml.load_unsafe does not flag a single-line SafeLoader call", () => {
+  assert.equal(
+    matches("py.yaml.load_unsafe", "yaml.load(f, Loader=yaml.SafeLoader)"),
+    false,
+  );
+});
+
+test("py.yaml.load_unsafe does not flag a SafeLoader call wrapped across lines", () => {
+  assert.equal(
+    matches(
+      "py.yaml.load_unsafe",
+      "yaml.load(\n    f,\n    Loader=yaml.SafeLoader,\n)",
+    ),
+    false,
+  );
+});
+
+test("py.yaml.load_unsafe still flags an unsafe call preceding a safe one", () => {
+  // Regression guard: an unbounded dotall lookahead would let the SECOND
+  // call's SafeLoader kwarg suppress the flag on the FIRST, unsafe call.
+  assert.equal(
+    matches(
+      "py.yaml.load_unsafe",
+      "yaml.load(a)\nyaml.load(b, Loader=yaml.SafeLoader)",
+    ),
+    true,
+  );
+});


### PR DESCRIPTION
## What gap this closes

`source_sink_scan` (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) is the heuristic recall tool the `recon`/`detector` agents use to widen the candidate list before reachability tracing (see the `mantis-pipeline`/`detection-breadth` skills). Its `py.yaml.load_unsafe` sink rule (CWE-502, unsafe deserialization) is supposed to exempt calls that pass the safe loader:

```js
pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
```

The exemption's negative lookahead uses `.*`, and `.` never matches `\n` without the `s` flag. So the exemption silently broke on any multi-line call — the common style once a call takes a `Loader=` kwarg:

```python
yaml.load(
    f,
    Loader=yaml.SafeLoader,
)
```

Verified against current `main`:

```
"yaml.load(f, Loader=yaml.SafeLoader)"                        -> flagged: false  (correct)
"yaml.load(\n    f,\n    Loader=yaml.SafeLoader,\n)"           -> flagged: true   (false positive)
```

This is a recall-vs-noise problem, not cosmetic: the rule exists specifically so a *safe* multi-line `yaml.load` call doesn't compete with real unsafe-deserialization candidates for Validate-stage attention, and multi-line kwargs are the more common formatting once a call takes a `Loader=` argument at all (Black/ruff-formatted code wraps calls with keyword args liberally).

## The fix

Swap the unbounded `.*` for a paren-bounded `[^)]*`:

```js
pattern: /\byaml\.load\s*\((?[^)]*Loader=yaml\.SafeLoader)/g,
```

`[^)]` matches `\n` natively (it's a negated class, not a dot), so it sees a `Loader=yaml.SafeLoader` kwarg on a later line of the *same* call. Just adding the `s` (dotall) flag to the original `.*` was **not** sufficient/correct — a bare dotall lookahead scans to the end of the file, so an unsafe `yaml.load(a)` earlier in a module would get silently exempted by a *different*, unrelated `yaml.load(b, Loader=yaml.SafeLoader)` call later on. `[^)]*` avoids that by stopping at this call's own closing paren. All four cases verified:

```
"yaml.load(user_input)"                                                  -> flagged: true   (unsafe, correctly flagged)
"yaml.load(f, Loader=yaml.SafeLoader)"                                   -> flagged: false  (safe, correctly exempted)
"yaml.load(\n    f,\n    Loader=yaml.SafeLoader,\n)"                     -> flagged: false  (safe multiline, now correctly exempted)
"yaml.load(a)\nyaml.load(b, Loader=yaml.SafeLoader)"                     -> flagged: true   (first call still correctly flagged)
```

## Testing

No unit tests previously existed for `source_sink_rules.js`, so I added a small `node:test` regression suite (`source_sink_rules.test.js`, zero new dependencies) covering the four cases above.

```
$ node --test .codex/mcp-servers/program-analysis/source_sink_rules.test.js
# tests 4
# pass 4
# fail 0
```

`npx prettier --check` passes on both changed files.

## Scope note

This is a different rule/regex from the other currently-open detection-breadth PRs touching this file (SQLi/SSRF sinks, PHP/Ruby languages, path traversal, the `innerHTML`/`RegExp.exec` false-positive fixes, etc.) — no overlap expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_019oXYbZ8ptkhXcweRKXPybA)_