### PR TITLE
fix: close secret-detection coverage gap between findings and http-audit

### DIFF
--- a/.codex/mcp-servers/findings/server.js
+++ b/.codex/mcp-servers/findings/server.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
 const { createServer } = require("../lib/mcp_stdio.js");
+const { containsSecretShape } = require("../lib/secret_patterns.js");
 
 /**
  * Mantis findings service -- the tool-owned findings spine (PRD section 9,
@@ -37,17 +38,6 @@ const STATUS_TRANSITIONS = {
 const VALID_STATUSES = Object.keys(STATUS_TRANSITIONS);
 const VALID_SEVERITIES = ["info", "low", "medium", "high", "critical"];
 
-// Cheap secret-shaped-string guard so raw credentials never land in a finding
-// or evidence blob (PRD section 9 "never raw secrets/tokens/cookies/full
-// bodies", section 11 secrets/DLP). This is a backstop, not a full DLP engine.
-const SECRET_PATTERNS = [
-  /\bAKIA[0-9A-Z]{16}\b/, // AWS access key id
-  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/, // GitHub tokens
-  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/, // Slack tokens
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----/, // PEM private keys
-  /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/, // JWTs
-];
-
 function ensureDataDir() {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
@@ -60,9 +50,13 @@ function newId() {
   return `MANTIS-${crypto.randomBytes(5).toString("hex")}`;
 }
 
+// Cheap secret-shaped-string guard so raw credentials never land in a finding
+// or evidence blob (PRD section 9 "never raw secrets/tokens/cookies/full
+// bodies", section 11 secrets/DLP). This is a backstop, not a full DLP
+// engine -- shares its pattern list with http-audit's redaction so the two
+// gates can't drift apart (see lib/secret_patterns.js).
 function scanForSecrets(value) {
-  const hay = typeof value === "string" ? value : JSON.stringify(value ?? "");
-  return SECRET_PATTERNS.some((re) => re.test(hay));
+  return containsSecretShape(value);
 }
 
 function appendEvent(event) {

--- a/.codex/mcp-servers/http-audit/server.js
+++ b/.codex/mcp-servers/http-audit/server.js
@@ -3,6 +3,7 @@
 
 const crypto = require("node:crypto");
 const { createServer } = require("../lib/mcp_stdio.js");
+const { redactAll } = require("../lib/secret_patterns.js");
 
 /**
  * Mantis HTTP-audit + request-refs (PRD section 6 "Proxy / traffic:
@@ -29,38 +30,17 @@ const SENSITIVE_HEADERS = new Set([
   "x-xsrf-token",
 ]);
 
-// Inline secret shapes that can appear anywhere in a body/URL.
-const SECRET_VALUE_PATTERNS = [
-  [/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]"],
-  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "[REDACTED_GH_TOKEN]"],
-  [/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[REDACTED_SLACK_TOKEN]"],
-  [
-    /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
-    "[REDACTED_JWT]",
-  ],
-  [
-    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
-    "[REDACTED_PRIVATE_KEY]",
-  ],
-  [/\b[A-Za-z0-9._%+-]+:[^@\s/]{6,}@/g, "[REDACTED_USERINFO]@"], // user:pass@ in URLs
-  // Generically-named secret-bearing query/form params -- shape-based patterns above
-  // can't catch these since the secret value itself has no distinctive shape.
-  [
-    /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
-    (_match, name) => `${name}=[REDACTED]`,
-  ],
-];
-
 const MAX_BODY_PREVIEW = 512;
 
 function sha256(s) {
   return crypto.createHash("sha256").update(s, "utf8").digest("hex");
 }
 
+// Inline secret shapes that can appear anywhere in a body/URL. Shared with
+// the findings server's create/update guard (lib/secret_patterns.js) so
+// both DLP gates see the same coverage.
 function redactValue(value) {
-  let out = String(value);
-  for (const [re, repl] of SECRET_VALUE_PATTERNS) out = out.replace(re, repl);
-  return out;
+  return redactAll(value);
 }
 
 // Splits a raw HTTP message into { startLine, headers[], body }. Tolerant of

--- a/.codex/mcp-servers/lib/secret_patterns.js
+++ b/.codex/mcp-servers/lib/secret_patterns.js
@@ -1,0 +1,57 @@
+"use strict";
+
+/**
+ * Canonical secret-shaped patterns shared by every Mantis MCP server that
+ * detects or redacts raw credentials (PRD section 9/11 DLP backstop).
+ *
+ * http-audit and findings used to keep independently-maintained copies of
+ * this list. They drifted: findings' create/update guard was missing the
+ * userinfo@ and generic `token=`/`password=`/... key-value shapes that
+ * http-audit already redacted, so a finding payload could carry a raw
+ * secret past the findings-spine gate even though http-audit would have
+ * caught the same string. Centralizing here means both gates see the same
+ * coverage and can't silently fall out of sync again.
+ */
+const SECRET_REDACT_PATTERNS = [
+  [/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]"],
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "[REDACTED_GH_TOKEN]"],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[REDACTED_SLACK_TOKEN]"],
+  [/\bsk_live_[A-Za-z0-9]{16,}\b/g, "[REDACTED_STRIPE_KEY]"],
+  [/\bAIza[A-Za-z0-9_-]{35}\b/g, "[REDACTED_GOOGLE_API_KEY]"],
+  [
+    /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    "[REDACTED_JWT]",
+  ],
+  [
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    "[REDACTED_PRIVATE_KEY]",
+  ],
+  [/\b[A-Za-z0-9._%+-]+:[^@\s/]{6,}@/g, "[REDACTED_USERINFO]@"], // user:pass@ in URLs
+  [
+    /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
+    (_match, name) => `${name}=[REDACTED]`,
+  ],
+];
+
+// Detection-only companion for the private-key shape: a bare BEGIN marker
+// with no matching END is still a leaked key (e.g. a truncated preview), so
+// boolean detection must not require the END anchor the redaction pattern
+// needs to know how much text to replace.
+const PRIVATE_KEY_BEGIN_ONLY = /-----BEGIN [A-Z ]*PRIVATE KEY-----/;
+
+function redactAll(text) {
+  let out = String(text);
+  for (const [re, repl] of SECRET_REDACT_PATTERNS) out = out.replace(re, repl);
+  return out;
+}
+
+function containsSecretShape(value) {
+  const hay = typeof value === "string" ? value : JSON.stringify(value ?? "");
+  if (PRIVATE_KEY_BEGIN_ONLY.test(hay)) return true;
+  return SECRET_REDACT_PATTERNS.some(([re]) => {
+    re.lastIndex = 0; // guard against stateful /g regex reuse
+    return re.test(hay);
+  });
+}
+
+module.exports = { SECRET_REDACT_PATTERNS, redactAll, containsSecretShape };


### PR DESCRIPTION
## What gap this closes

The Mantis findings-spine has two independent raw-secret DLP gates that are supposed to agree with each other:

- `http-audit`'s `SECRET_VALUE_PATTERNS` — redacts secret-shaped strings out of HTTP evidence packs before they're attached to a finding.
- `findings`'s `scanForSecrets` — refuses to `finding_create`/`finding_update` if the payload looks like it contains a raw secret.

They were maintained as two hand-copied pattern lists and had drifted apart. `findings`'s guard was **missing**:

- the `user:pass@` URL-userinfo shape
- the generic `token=`/`api_key=`/`password=`/`secret=`/... key-value shape (the one PRD section 11 calls out specifically, since these secrets have no distinctive shape of their own)

That means a finding's `claim`/`evidence`/`poc` field could carry a raw credential (e.g. a `password=hunter2...` string pasted into a PoC, or a `https://user:pass@host/...` URL) straight past the findings-spine gate, even though `http-audit` would have redacted the exact same string a stage earlier. Since findings are meant to be safe to read/report without ever holding raw secrets (PRD section 9/11), this is a real DLP miss, not just cosmetic drift.

## What changed

- Added `.codex/mcp-servers/lib/secret_patterns.js`: single canonical pattern list (`SECRET_REDACT_PATTERNS`) plus `redactAll()` and `containsSecretShape()` helpers.
- `http-audit/server.js` now redacts via the shared `redactAll()` instead of its own local copy.
- `findings/server.js`'s `scanForSecrets` now delegates to the shared `containsSecretShape()`, so it has the same coverage as `http-audit`.
- Also widened coverage for both gates: added Stripe (`sk_live_...`) and Google API key (`AIza...`) shapes, two very common leaked-secret formats that neither gate previously recognized.
- Kept detection deliberately more conservative than redaction for the PEM private-key case: `containsSecretShape` flags a bare `-----BEGIN ... PRIVATE KEY-----` marker even without a matching `END` line (e.g. a truncated preview), whereas redaction still needs the full `BEGIN...END` block to know what to replace.

Centralizing the pattern list means the two gates can no longer silently fall out of sync — a future new secret shape only needs to be added once.

## Why

This is a small, focused fix inside the Mantis security-tooling substrate itself (the findings spine and HTTP evidence pipeline), not the target codebases it scans. Verified with `node -e` sanity checks exercising all previously-covered shapes (still caught), the two previously-missed shapes (now caught), the two new shapes (now caught), and a redaction round-trip; also confirmed both MCP servers still `require()` cleanly and `prettier --check` is clean on the touched files.

## Test plan

- [x] `node -e` assertions: previously-covered secret shapes (AWS key, GH token, Slack token, JWT, PEM key) still detected
- [x] `node -e` assertions: previously-missing shapes (`user:pass@`, generic `token=`/`api_key=`) now detected by `findings`' guard
- [x] `node -e` assertions: new Stripe/Google API key shapes detected
- [x] `node -e` assertions: non-secret text does not false-positive
- [x] `redactAll` round-trip still strips values from a raw HTTP body
- [x] Both `http-audit/server.js` and `findings/server.js` still `require()` without error
- [x] `prettier --check` clean on all three touched files


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sLpM9Uoemq3eTK9AzPuS)_