### PR TITLE
fix: stop trufflehog_scan from leaking real secret characters

### DIFF
--- a/.codex/mcp-servers/trufflehog/server.js
+++ b/.codex/mcp-servers/trufflehog/server.js
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 "use strict";
 
+const crypto = require("node:crypto");
 const { createServer } = require("../lib/mcp_stdio.js");
 const { runCommand, notFoundMessage } = require("../lib/run_tool.js");
 
 // Never forward raw secret material. Per the Mantis evidence-handling
 // contract, findings/evidence/reports must never contain live secrets --
-// only enough to prove a match exists and where.
+// only enough to prove a match exists and where. Previously this echoed the
+// first/last 4 characters of the actual secret, which leaks real credential
+// material (especially for `--only-verified` hits, i.e. LIVE, working
+// secrets) into findings/reports that may be shared or persisted. A content
+// hash gives the same dedup/cross-reference value as the *_ref ids used by
+// mantis_http_audit without ever exposing a byte of the real secret.
 function redact(secret) {
   if (!secret) return "[REDACTED_SECRET]";
-  if (secret.length <= 8) return "[REDACTED_SECRET]";
-  return `${secret.slice(0, 4)}...[REDACTED ${secret.length} chars]...${secret.slice(-4)}`;
+  const hash = crypto
+    .createHash("sha256")
+    .update(secret, "utf8")
+    .digest("hex")
+    .slice(0, 12);
+  return `[REDACTED_SECRET sha256:${hash} len:${secret.length}]`;
 }
 
 async function trufflehogScan({ path: targetPath, only_verified = false }) {


### PR DESCRIPTION
## What gap this closes

`mantis_trufflehog`'s `redact()` helper (`.codex/mcp-servers/trufflehog/server.js`) was echoing the **first 4 and last 4 characters** of every matched secret into `candidate` findings -- including hits found with `only_verified: true`, i.e. secrets trufflehog live-verified as still-working credentials.

That directly contradicts the evidence-handling invariant this repo enforces everywhere else:
- `mantis_findings`' `scanForSecrets` guard refuses to store a payload that looks like a raw secret.
- `mantis_http_audit` fully redacts sensitive headers/values to `[REDACTED_*]`, never a partial value.
- The PRD language quoted right above the old `redact()` function: *"Never forward raw secret material... findings/evidence/reports must never contain live secrets."*

8 real characters of a verified, currently-working credential is meaningful leakage on its own (many API keys/tokens are only 20-40 chars total), and it's inconsistent with how every other scanner server in this repo handles secret material.

## The fix

Replace the partial-character echo with a truncated `sha256` content hash + length:

```js
function redact(secret) {
  if (!secret) return "[REDACTED_SECRET]";
  const hash = crypto.createHash("sha256").update(secret, "utf8").digest("hex").slice(0, 12);
  return `[REDACTED_SECRET sha256:${hash} len:${secret.length}]`;
}
```

This preserves the useful properties of the old output (stable identity for dedup/cross-referencing the same secret across runs, rough length) using the same `*_ref`-style content-hash pattern `mantis_http_audit` already uses for `request_ref`/`response_ref` -- without ever emitting a byte of the actual secret.

## Verification

- `node --check .codex/mcp-servers/trufflehog/server.js`
- `npx prettier --check .codex/mcp-servers/trufflehog/server.js`
- Manually exercised `redact()` with empty/short/long inputs to confirm no secret characters survive and the format is stable for the same input.

No existing test suite covers the `.codex/mcp-servers/*` JS servers (none found under `.codex`), so this was verified via direct execution rather than a test run.

---
Opened by the recurring mantis maintenance routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZM8a1D7edbg9AqSLkux4q)_