### PR TITLE
detect: normalize codeql_analyze severity to the shared finding vocabulary

### DIFF
--- a/.codex/mcp-servers/codeql/server.js
+++ b/.codex/mcp-servers/codeql/server.js
@@ -6,6 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { createServer } = require("../lib/mcp_stdio.js");
 const { runCommand, notFoundMessage } = require("../lib/run_tool.js");
+const { buildRuleSeverityIndex, severityForResult } = require("./severity.js");
 
 const CODEQL_NOT_FOUND = notFoundMessage(
   "codeql",
@@ -92,6 +93,7 @@ async function codeqlAnalyze({
 
   const findings = [];
   for (const run of sarif.runs || []) {
+    const ruleSeverityIndex = buildRuleSeverityIndex(run);
     for (const result_ of run.results || []) {
       const loc =
         result_.locations &&
@@ -100,6 +102,7 @@ async function codeqlAnalyze({
       findings.push({
         rule_id: result_.ruleId,
         level: result_.level || "warning",
+        severity: severityForResult(result_, ruleSeverityIndex),
         message: result_.message && result_.message.text,
         path: loc && loc.artifactLocation && loc.artifactLocation.uri,
         start_line: loc && loc.region && loc.region.startLine,
@@ -150,7 +153,7 @@ createServer({
     {
       name: "codeql_analyze",
       description:
-        "Run CodeQL query-suite analysis (default security-extended) against a database built by codeql_create_database. Emits `candidate` SAST findings with dataflow-backed rule IDs.",
+        "Run CodeQL query-suite analysis (default security-extended) against a database built by codeql_create_database. Emits `candidate` SAST findings with dataflow-backed rule IDs; each finding's `severity` is normalized to info/low/medium/high/critical (from the rule's security-severity score where present, else SARIF level) so it can be passed straight into finding_create/finding_update.",
       inputSchema: {
         type: "object",
         properties: {

--- a/.codex/mcp-servers/codeql/severity.js
+++ b/.codex/mcp-servers/codeql/severity.js
@@ -1,0 +1,74 @@
+"use strict";
+
+/**
+ * Normalizes a CodeQL SARIF result into the info/low/medium/high/critical
+ * severity vocabulary that mantis_findings requires (see findings/server.js
+ * VALID_SEVERITIES). Every other Detect-stage server (semgrep, bandit,
+ * trivy) already maps its tool-native severity into that vocabulary;
+ * codeql_analyze was the one holdout, returning only the raw SARIF `level`
+ * (error/warning/note) -- not a legal finding severity, and coarser than
+ * CodeQL's own per-rule `security-severity` CVSS-like score. Split into its
+ * own module (no side effects) so it's unit-testable without importing
+ * server.js, which starts listening on stdin as soon as it's required.
+ */
+
+// Bucket boundaries follow GitHub's own security-severity -> criticality
+// mapping (docs.github.com/code-security/code-scanning).
+function severityFromSecurityScore(score) {
+  if (score >= 9) return "critical";
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  if (score > 0) return "low";
+  return null;
+}
+
+function severityFromSarifLevel(level) {
+  if (level === "error") return "high";
+  if (level === "warning") return "medium";
+  if (level === "note") return "low";
+  return "info";
+}
+
+// SARIF keys each result's rule by id, and defines the rule (with its
+// security-severity property) once per run under tool.driver.rules and/or
+// tool.extensions[].rules -- index them so each result can look its rule up.
+function buildRuleSeverityIndex(run) {
+  const index = new Map();
+  const collect = (rules) => {
+    for (const rule of rules || []) {
+      const props = rule.properties || {};
+      const rawScore = props["security-severity"];
+      const score = rawScore === undefined ? NaN : Number.parseFloat(rawScore);
+      index.set(rule.id, {
+        securitySeverity: Number.isFinite(score) ? score : null,
+        problemSeverity: props["problem.severity"] || null,
+      });
+    }
+  };
+  collect(run.tool && run.tool.driver && run.tool.driver.rules);
+  for (const ext of (run.tool && run.tool.extensions) || []) {
+    collect(ext.rules);
+  }
+  return index;
+}
+
+function severityForResult(result_, ruleSeverityIndex) {
+  const rule = ruleSeverityIndex.get(result_.ruleId);
+  if (rule) {
+    if (rule.securitySeverity !== null) {
+      const bucket = severityFromSecurityScore(rule.securitySeverity);
+      if (bucket) return bucket;
+    }
+    if (rule.problemSeverity === "error") return "high";
+    if (rule.problemSeverity === "warning") return "medium";
+    if (rule.problemSeverity === "recommendation") return "low";
+  }
+  return severityFromSarifLevel(result_.level || "warning");
+}
+
+module.exports = {
+  severityFromSecurityScore,
+  severityFromSarifLevel,
+  buildRuleSeverityIndex,
+  severityForResult,
+};

--- a/.codex/mcp-servers/codeql/severity.test.js
+++ b/.codex/mcp-servers/codeql/severity.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { buildRuleSeverityIndex, severityForResult } = require("./severity.js");
+
+function run(rules, results) {
+  return { tool: { driver: { rules } }, results };
+}
+
+test("prefers the rule's security-severity score over SARIF level", () => {
+  const r = run(
+    [{ id: "js/sql-injection", properties: { "security-severity": "9.8" } }],
+    [{ ruleId: "js/sql-injection", level: "warning" }],
+  );
+  const index = buildRuleSeverityIndex(r);
+  assert.equal(severityForResult(r.results[0], index), "critical");
+});
+
+test("buckets security-severity at the documented thresholds", () => {
+  const cases = [
+    ["9.8", "critical"],
+    ["7.2", "high"],
+    ["5.5", "medium"],
+    ["2.0", "low"],
+  ];
+  for (const [score, expected] of cases) {
+    const r = run(
+      [{ id: "rule-x", properties: { "security-severity": score } }],
+      [{ ruleId: "rule-x", level: "note" }],
+    );
+    const index = buildRuleSeverityIndex(r);
+    assert.equal(severityForResult(r.results[0], index), expected);
+  }
+});
+
+test("falls back to problem.severity when security-severity is absent", () => {
+  const r = run(
+    [{ id: "rule-y", properties: { "problem.severity": "recommendation" } }],
+    [{ ruleId: "rule-y", level: "warning" }],
+  );
+  const index = buildRuleSeverityIndex(r);
+  assert.equal(severityForResult(r.results[0], index), "low");
+});
+
+test("falls back to SARIF level when the rule isn't found at all", () => {
+  const r = run([], [{ ruleId: "unknown-rule", level: "error" }]);
+  const index = buildRuleSeverityIndex(r);
+  assert.equal(severityForResult(r.results[0], index), "high");
+});
+
+test("defaults a missing level like SARIF itself defaults to warning", () => {
+  const r = run([], [{ ruleId: "unknown-rule" }]);
+  const index = buildRuleSeverityIndex(r);
+  assert.equal(severityForResult(r.results[0], index), "medium");
+});
+
+test("severityFromSarifLevel falls back to info for a genuinely unknown level", () => {
+  const { severityFromSarifLevel } = require("./severity.js");
+  assert.equal(severityFromSarifLevel("none"), "info");
+});
+
+test("reads rules from tool.extensions[].rules too", () => {
+  const r = {
+    tool: {
+      driver: { rules: [] },
+      extensions: [
+        {
+          rules: [
+            { id: "ext-rule", properties: { "security-severity": "8.0" } },
+          ],
+        },
+      ],
+    },
+    results: [{ ruleId: "ext-rule", level: "note" }],
+  };
+  const index = buildRuleSeverityIndex(r);
+  assert.equal(severityForResult(r.results[0], index), "high");
+});


### PR DESCRIPTION
## What gap this closes

Every other Detect-stage server normalizes its tool-native severity into the shared `info/low/medium/high/critical` vocabulary that `mantis_findings` enforces (`VALID_SEVERITIES` in `.codex/mcp-servers/findings/server.js`): semgrep maps `ERROR/WARNING/INFO`, bandit maps `HIGH/MEDIUM/LOW`, trivy maps `CRITICAL/HIGH/MEDIUM/LOW/UNKNOWN`. `codeql_analyze` (`.codex/mcp-servers/codeql/server.js`) was the one holdout: it only ever returned the raw SARIF `level` (`error`/`warning`/`note`), which is not a legal `finding_create`/`finding_update` severity and also ignores CodeQL's own per-rule `security-severity` CVSS-like score (a much more accurate signal than the 3-value `level`). In practice this meant an agent taking a CodeQL finding straight to `finding_create` either had to guess a severity (inconsistent with the other five detectors) or pass the raw `level` and get it rejected.

No overlap with any currently open detection PR from this routine — this is scoped entirely to `.codex/mcp-servers/codeql/`, which none of the other open PRs touch.

## What changed

- Extracted the new mapping logic into a pure, side-effect-free module, `.codex/mcp-servers/codeql/severity.js`, so it's unit-testable without importing `server.js` (which starts listening on stdin as soon as it's required — the reason none of the other server.js files have direct unit tests today).
- `severityForResult(result, ruleSeverityIndex)`: prefers the rule's `security-severity` score (bucketed at the same 9/7/4 thresholds GitHub code scanning itself uses: critical/high/medium/low), falls back to the rule's `problem.severity`, then falls back to mapping the SARIF `level` (`error`→high, `warning`→medium, `note`→low, default→info — matching the existing `level` default of `"warning"`).
- `buildRuleSeverityIndex(run)`: indexes a SARIF run's `tool.driver.rules` and `tool.extensions[].rules` by rule id so each result can look up its own rule's severity metadata.
- `codeqlAnalyze()` now attaches a `severity` field to every finding alongside the existing `level`, ready to pass straight into `finding_create`/`finding_update`.
- Updated the tool description to document the new field.

Additive only: the existing `level`, `rule_id`, `message`, `path`, `start_line` fields are unchanged.

## Testing

```
node --check .codex/mcp-servers/codeql/server.js
node --check .codex/mcp-servers/codeql/severity.js
node --test .codex/mcp-servers/codeql/severity.test.js
# 7 pass, 0 fail

npx prettier --check .codex/mcp-servers/codeql/server.js .codex/mcp-servers/codeql/severity.js .codex/mcp-servers/codeql/severity.test.js
# All matched files use Prettier code style!
```

Also confirmed `require("./.codex/mcp-servers/codeql/server.js")` loads and returns without hanging (it registers stdin listeners like every other MCP server here, so it isn't unit-testable directly — hence the split into `severity.js`).

New tests (`severity.test.js`, Node's built-in `node:test`, zero new deps) cover: security-severity taking priority over SARIF level, bucket boundaries at 9/7/4, `problem.severity` fallback, SARIF `level` fallback when a rule isn't indexed at all, the SARIF default-to-`"warning"` behavior when `level` is missing, and rules declared under `tool.extensions[].rules` instead of `tool.driver.rules`.

## Scope

Small and focused: one new pure module + its tests, a 6-line change to `codeql/server.js` to call it, and a one-line description update. No schema change to the tool's existing output fields, no changes to any other detector.

## Scan report (task 2 of this routine)

Could not run the authorized discovery scan against `https://vulnerable-bounty-site.vercel.app` this cycle: the environment's own egress proxy rejects the CONNECT to this host at the policy layer (`gateway answered 403 to CONNECT (policy denial or upstream failure)`, confirmed via both `curl` and the proxy's own `/__agentproxy/status` failure log, host `vulnerable-bounty-site.vercel.app:443`, timestamped minutes before this PR). Per the environment's explicit proxy guidance, policy denials (403/407) must be reported rather than retried or routed around, so no scan ran and no findings are reported this cycle.

This is not a one-off: PR #108 (2026-07-08, three days prior) hit the identical 403 policy denial against the same host. The block has been standing for at least three days across multiple runs of this routine — task 2 has not been able to execute even once in this environment as currently configured. Flagging so the egress policy for this session/environment can be reviewed if scanning this target is meant to work here.

---
Opened by the recurring mantis maintenance routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzrqHDnzdsZP8X4pNbMiVW)_