### PR TITLE
fix: close reasoning_trace_ref confirm-without-proof loophole in findings spine

### DIFF
--- a/.codex/mcp-servers/findings/server.js
+++ b/.codex/mcp-servers/findings/server.js
@@ -218,9 +218,16 @@ function findingUpdate(args) {
       );
     }
     if (status === "confirmed") {
+      // `reasoning_trace_ref` is just a pointer to the candidate's reasoning
+      // trace, set freely at finding_create time -- it is not proof of a
+      // traced source->sink path. Treating its mere presence as sufficient
+      // reachability evidence let a candidate self-confirm without ever
+      // calling reachability/attack-sim, defeating the "no proof -> no
+      // confirm" invariant (PRD FR-6.1/6.3, findings-spine skill). Only an
+      // explicit reachability_note on this call, or an actual evidence entry
+      // (existing or freshly attached), counts.
       const hasReach =
         args.reachability_note ||
-        existing.reasoning_trace_ref ||
         (Array.isArray(existing.evidence) && existing.evidence.length > 0) ||
         (Array.isArray(evidence) && evidence.length > 0);
       if (!hasReach) {


### PR DESCRIPTION
## What gap this closes

`.codex/mcp-servers/findings/server.js`'s `finding_update` enforces "no proof -> no confirm" for the `candidate -> confirmed` transition (PRD FR-6.1/6.3, `findings-spine` skill). The gate (`hasReach`) accepted any of:

- `args.reachability_note` passed on this call
- `existing.reasoning_trace_ref` set on the finding
- a non-empty `evidence` array (existing or freshly attached)

The second condition is the bug: `reasoning_trace_ref` is just a free-text pointer to a reasoning trace, set optionally at `finding_create` time -- it documents *why a candidate was flagged*, not that reachability/attacker-simulation was ever performed. Since most candidates from Detect-stage tooling (semgrep/CodeQL/manual reasoning) will naturally carry some trace ref, this let a finding go straight from `candidate` to `confirmed` with **zero** `reachability_note` and **zero** evidence attached -- silently defeating the ruthless-Validate discipline the whole pipeline is built on ("what survives attacker-simulation is real").

## Fix

Drop the `existing.reasoning_trace_ref` branch from the confirm gate. Confirming now requires an explicit `reachability_note` on the call, or an actual evidence entry (pre-existing or attached in the same call) -- matching what the tool description and the `findings-spine` skill already claim the server enforces.

## Verification

- `node --check .codex/mcp-servers/findings/server.js`
- `npx prettier --check .codex/mcp-servers/findings/server.js`
- Manual repro against the compiled handlers (no test harness exists yet for these MCP servers, consistent with prior PRs in this series):
  - `finding_create({ vuln_class: "sql-injection", claim: "test", reasoning_trace_ref: "trace-123" })` then `finding_update({ id, status: "confirmed" })` **before** the fix silently succeeded; **after** the fix it throws `Confirming a finding requires reachability/attack-simulation evidence: ...`.
  - `finding_update({ id, status: "confirmed", reachability_note: "traced req.query -> eval() at line 10" })` still confirms successfully, as expected.

No other files touch this code path; this is a one-file, low-risk fix scoped to the findings-lifecycle enforcement logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVvArrpgk8Y6WkKHWuimfT)_