### PR TITLE
detect: add XXE (CWE-611) sink coverage to source_sink_scan

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -129,6 +129,27 @@ const RULES = [
     pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.xxe.lxml_etree",
+    pattern: /\blxml\.etree\.(parse|fromstring|XMLParser)\s*\(/g,
+    cwe: "CWE-611",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.xxe.xml_sax",
+    pattern: /\bxml\.sax\.(make_parser|parse|parseString)\s*\(/g,
+    cwe: "CWE-611",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.xxe.xml_minidom",
+    pattern: /\bxml\.dom\.minidom\.(parse|parseString)\s*\(/g,
+    cwe: "CWE-611",
+  },
 
   // Go
   {
@@ -187,6 +208,27 @@ const RULES = [
     id: "java.statement.execute",
     pattern: /\bstatement\.execute(Query|Update)?\s*\(/gi,
     cwe: "CWE-89",
+  },
+  {
+    lang: "java",
+    kind: "sink",
+    id: "java.xxe.documentbuilderfactory",
+    pattern: /\bDocumentBuilderFactory\.newInstance\s*\(/g,
+    cwe: "CWE-611",
+  },
+  {
+    lang: "java",
+    kind: "sink",
+    id: "java.xxe.saxparserfactory",
+    pattern: /\bSAXParserFactory\.newInstance\s*\(/g,
+    cwe: "CWE-611",
+  },
+  {
+    lang: "java",
+    kind: "sink",
+    id: "java.xxe.xmlinputfactory",
+    pattern: /\bXMLInputFactory\.new(Instance|Factory)\s*\(/g,
+    cwe: "CWE-611",
   },
 ];
 


### PR DESCRIPTION
## Gap this closes

`source_sink_scan`'s heuristic rule set (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) had zero coverage for XML External Entity injection (CWE-611) — a distinct OWASP-class vuln with no overlap in scope with the SQLi/SSRF/path-traversal/prototype-pollution/weak-crypto sink PRs already open on this repo. Existing rules span command injection, deserialization, and XSS sinks, but nothing flags XML-parser entry points where external entity resolution is a classic, high-severity bug.

## What changed

Added candidate-sink rules (`kind: "sink"`, `cwe: "CWE-611"`) for the standard XXE-prone parser constructors, following the existing detect-generous style (flag the call site; Validate/Reachability stages trace whether external-entity resolution is actually enabled and reachable):

- **Java**: `DocumentBuilderFactory.newInstance()`, `SAXParserFactory.newInstance()`, `XMLInputFactory.new(Instance|Factory)()`
- **Python**: `lxml.etree.(parse|fromstring|XMLParser)()`, `xml.sax.(make_parser|parse|parseString)()`, `xml.dom.minidom.(parse|parseString)()`

No changes to `server.js` — Java/Python are already in `EXTENSION_TO_LANG`.

## Why these specific sinks

These are the canonical XXE entry points cited in OWASP's XXE Prevention Cheat Sheet: `DocumentBuilderFactory`/`SAXParserFactory`/`XMLInputFactory` all default to external-entity resolution enabled unless explicitly disabled (`FEATURE_SECURE_PROCESSING`, disallow-doctype-decl, etc.), and `lxml`'s default parser has `resolve_entities=True`. Python's stdlib `xml.etree.ElementTree` was deliberately excluded — CPython 3.7.1+ ships it hardened against external entities by default, so flagging it would just add noise without a real weakness behind it.

## Testing

No existing test harness for `source_sink_rules.js` (none of the other sink-coverage PRts in this repo added one either). Verified manually: extracted the rule-matching loop from `sourceSinkScan` and ran it against synthetic Java/Python snippets exercising each new sink — all three Java rules and all three Python rules fired on their respective constructs, and a spot-check of the full 33-rule set showed no regressions in existing matches. Also ran `npx prettier --check` on the changed file (passes).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UPatVCWqbBvKGag3CQWjUT)_