### PR TITLE
Add SQL-injection sink rules to the source/sink heuristic scanner

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -79,6 +79,20 @@ const RULES = [
     pattern: /\b(node-serialize|serialize\.unserialize)\s*\(/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.sql.query_template_literal",
+    pattern: /\.(query|execute)\s*\(\s*`[^`]*\$\{/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.sql.query_string_concat",
+    pattern: /\.(query|execute)\s*\(\s*['"][^'"]*['"]\s*\+/g,
+    cwe: "CWE-89",
+  },
 
   // Python
   {
@@ -129,6 +143,27 @@ const RULES = [
     pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_fstring",
+    pattern: /\.execute\s*\(\s*f['"]/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_percent_or_concat",
+    pattern: /\.execute\s*\(\s*['"][^'"]*['"]\s*(%|\+)/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_format_call",
+    pattern: /\.execute\s*\(\s*['"][^'"]*['"]\s*\.\s*format\s*\(/g,
+    cwe: "CWE-89",
+  },
 
   // Go
   {
@@ -151,6 +186,20 @@ const RULES = [
     id: "go.template.html",
     pattern: /\btemplate\.HTML\s*\(/g,
     cwe: "CWE-79",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.sql.query_concat",
+    pattern: /\.(Query|QueryRow|Exec)\s*\(\s*(`[^`]*`|"[^"]*")\s*\+/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.sql.query_sprintf",
+    pattern: /\.(Query|QueryRow|Exec)\s*\(\s*fmt\.Sprintf\s*\(/g,
+    cwe: "CWE-89",
   },
 
   // Java

--- a/.codex/mcp-servers/program-analysis/test_source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/test_source_sink_rules.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Lightweight smoke test for source_sink_rules.js -- no test framework
+ * dependency, run with `node test_source_sink_rules.js`.
+ *
+ * Covers the SQL-injection sink rules (CWE-89) added for js/py/go: each
+ * must fire on an unparameterized query built from string concat/format,
+ * and must NOT fire on the equivalent parameterized-query call, so the
+ * heuristic stays high-signal instead of flagging every DB call.
+ */
+const assert = require("node:assert");
+const { RULES } = require("./source_sink_rules.js");
+
+function matches(ruleId, content) {
+  const rule = RULES.find((r) => r.id === ruleId);
+  assert(rule, `no rule registered with id ${ruleId}`);
+  rule.pattern.lastIndex = 0;
+  return rule.pattern.test(content);
+}
+
+const cases = [
+  // [ruleId, vulnerableSnippet, safeSnippet]
+  [
+    "js.sql.query_template_literal",
+    "db.query(`SELECT * FROM users WHERE id = ${id}`)",
+    "db.query('SELECT * FROM users WHERE id = ?', [id])",
+  ],
+  [
+    "js.sql.query_string_concat",
+    'connection.query("SELECT * FROM users WHERE id = " + id)',
+    "connection.query('SELECT * FROM users WHERE id = ?', [id])",
+  ],
+  [
+    "py.sql.execute_fstring",
+    'cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")',
+    'cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))',
+  ],
+  [
+    "py.sql.execute_percent_or_concat",
+    'cursor.execute("SELECT * FROM users WHERE id = " + user_id)',
+    'cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))',
+  ],
+  [
+    "py.sql.execute_format_call",
+    'cursor.execute("SELECT * FROM users WHERE id = {}".format(user_id))',
+    'cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))',
+  ],
+  [
+    "go.sql.query_concat",
+    'db.Query("SELECT * FROM users WHERE id = " + id)',
+    'db.Query("SELECT * FROM users WHERE id = $1", id)',
+  ],
+  [
+    "go.sql.query_sprintf",
+    'db.Exec(fmt.Sprintf("SELECT * FROM users WHERE id = %s", id))',
+    'db.Exec("SELECT * FROM users WHERE id = $1", id)',
+  ],
+];
+
+let failures = 0;
+for (const [ruleId, vulnerable, safe] of cases) {
+  if (!matches(ruleId, vulnerable)) {
+    failures++;
+    console.error(`FAIL ${ruleId}: expected to match vulnerable snippet`);
+  }
+  if (matches(ruleId, safe)) {
+    failures++;
+    console.error(
+      `FAIL ${ruleId}: unexpectedly matched parameterized/safe snippet`,
+    );
+  }
+}
+
+if (failures > 0) {
+  console.error(`${failures} failure(s)`);
+  process.exit(1);
+}
+console.log(`ok - ${cases.length} SQL-injection sink rules verified`);


### PR DESCRIPTION
## What gap this closes

`program-analysis/source_sink_rules.js` is the dependency-free heuristic source/sink tagger the `detector` and `recon` agents fall back on when semgrep/CodeQL aren't available (or to widen recall alongside them). It had **zero CWE-89 (SQL injection) sink signatures for JavaScript, Python, or Go** — only Java's generic `statement.execute()` call was covered. That's a real coverage gap: SQLi is one of the vulnerability classes the Mantis pipeline is explicitly meant to catch, and it's completely invisible to this scanner for three of the four supported languages.

## What changed

Added 7 new sink rules (all `CWE-89`), one per unparameterized-query-construction pattern per language:

- **JS/TS**: `.query()`/`.execute()` called with a template literal containing `${...}` interpolation, or with string concatenation (`+`)
- **Python**: `.execute()` called with an f-string, `%`-formatting, string concatenation, or a `.format()` call
- **Go**: `.Query()`/`.QueryRow()`/`.Exec()` called with string concatenation, or with `fmt.Sprintf(...)`

Each rule targets the actual injection *pattern* (unparameterized string construction at the call site) rather than flagging every DB call, so it stays high-signal instead of drowning the Detect stage in trivial candidates from properly-parameterized queries.

## Testing

Added `test_source_sink_rules.js`, a standalone smoke test (no framework, run via `node`) that asserts each new rule:
1. fires on a representative vulnerable snippet, and
2. does **not** fire on the equivalent parameterized/safe call

```
$ node .codex/mcp-servers/program-analysis/test_source_sink_rules.js
ok - 7 SQL-injection sink rules verified
```

Also ran `prettier --check` on both touched files (repo's existing `format` script covers `**/*.js`).

## Scope

Small, additive, read-only change to detection signatures only — no changes to the MCP server's request/response shape, no new dependencies, no changes to any other pipeline stage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8yeWdzwiGs3JRcCATVkof)_