### PR TITLE
fix: redact JSON-body secrets in http_audit, not just key=value form

### DIFF
--- a/.codex/mcp-servers/http-audit/server.js
+++ b/.codex/mcp-servers/http-audit/server.js
@@ -49,6 +49,13 @@ const SECRET_VALUE_PATTERNS = [
     /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
     (_match, name) => `${name}=[REDACTED]`,
   ],
+  // Same generic key family, but in JSON body shape ("key": "value") rather
+  // than form/query shape (key=value) -- REST APIs overwhelmingly send
+  // credentials this way and the key= pattern above never matches a colon.
+  [
+    /"(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)"\s*:\s*"(?:[^"\\]|\\.)*"/gi,
+    (_match, name) => `"${name}":"[REDACTED]"`,
+  ],
 ];
 
 const MAX_BODY_PREVIEW = 512;


### PR DESCRIPTION
## What gap this closes

`.codex/mcp-servers/http-audit/server.js`'s `SECRET_VALUE_PATTERNS` includes a generic pattern for secret-named keys (`token`, `api_key`, `password`, `secret`, ...) whose *values* have no distinctive shape of their own. That pattern only matched the form/query-string shape:

```
token=abcd1234...
```

It never matched the JSON body shape:

```json
{"password": "SuperSecret123!"}
```

...because there's no `=` character anywhere in JSON syntax — the pattern requires one. Since REST APIs overwhelmingly send credentials as JSON request/response bodies rather than form-encoded params, this was a real false-negative in the evidence-pack redaction: a `password`/`api_key`/`token`/etc. field in a JSON body would sail straight through `http_audit` and into a finding's evidence pack in cleartext, violating the invariant this tool exists to enforce ("Secret-bearing headers and inline secrets are stripped... never raw secrets" — see the tool's own docstring and the `secrets-scan`/`http-evidence` skills).

This is distinct from PR #116 (parity between `http-audit`'s and `findings`' pattern lists) and #119 (trufflehog's partial-secret-character leak) — neither of those touches the underlying regex's inability to match colon-separated JSON key/value pairs.

## What changed

Added one more entry to `SECRET_VALUE_PATTERNS` for the same generic secret-key family, matching the JSON `"key": "value"` shape and redacting the value the same way the form-shape entry already does. The existing `key=value` entry is untouched, so form/query-string redaction behavior is unchanged.

## Verification

No test suite covers `.codex/mcp-servers/*` (consistent with prior PRs in this area), so verified via direct execution:

- `node --check .codex/mcp-servers/http-audit/server.js` — clean
- Loaded the module (stubbing the stdio transport) and exercised `http_audit` directly:
  - JSON body `{"username":"alice","password":"SuperSecret123!"}` → password now redacted, non-secret fields untouched
  - JSON body with `api_key` → redacted; sibling non-secret field (`note`) preserved verbatim (no over-redaction)
  - Regression check: existing form-encoded `token=abcd1234efgh5678&user=bob` still redacts exactly as before
- `npx prettier --check .codex/mcp-servers/http-audit/server.js` — clean

## Scope note

Small, single-file, single-regex addition to the security-tooling substrate itself (not a target codebase). No behavior change to any previously-working redaction path.

---
Opened by the recurring mantis maintenance routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01STJ3cAxTHzJYweTUxGwbDR)_