### PR TITLE
fix: redact generically-named secrets in JSON-shaped http_audit bodies

### DIFF
--- a/.codex/mcp-servers/http-audit/server.js
+++ b/.codex/mcp-servers/http-audit/server.js
@@ -49,6 +49,15 @@ const SECRET_VALUE_PATTERNS = [
     /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
     (_match, name) => `${name}=[REDACTED]`,
   ],
+  // Same generically-named secret keys, but in JSON/JS-object body shape
+  // ("key": "value" or key: 'value') instead of form/query encoding -- JSON
+  // is the dominant modern API body format and was previously missed
+  // entirely, so a JSON request/response body sailed through un-redacted.
+  [
+    /(["']?)\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)\1\s*:\s*(["'])[^"']*\3/gi,
+    (_match, keyQuote, name, valueQuote) =>
+      `${keyQuote}${name}${keyQuote}: ${valueQuote}[REDACTED]${valueQuote}`,
+  ],
 ];
 
 const MAX_BODY_PREVIEW = 512;


### PR DESCRIPTION
## What gap this closes

`mantis_http_audit` (`.codex/mcp-servers/http-audit/server.js`) is the DAST evidence tool used to turn a captured HTTP request/response into a bounded, redacted evidence pack before it's attached to a finding. Its stated invariant (see `SKILL.md` for `http-evidence`) is that raw secrets must never land in a finding, artifact, report, or prompt.

Its generic secret-key redaction pattern only matched form/query-encoded pairs:

```
token=abc123&other=1   -> token=[REDACTED]&other=1   (caught)
```

But it never matched JSON-object shaped bodies, which is the dominant format for modern API request/response bodies:

```
{"username":"bob","password":"hunter2","api_key":"sk_live_..."}
```

Before this change, that whole body passed through `http_audit` untouched — `password` and `api_key` values leaked verbatim into the evidence pack (verified locally before the fix; see reproduction below). Only the pre-existing shape-based patterns (AWS keys, GitHub/Slack tokens, JWTs, PEM private keys) would still catch specific credential formats; a generically-named JSON secret field with no distinctive shape (a plain password, an opaque session token, etc.) had no coverage at all.

## The fix

Added a second generic pattern alongside the existing form/query one, matching `"key": "value"` / `key: 'value'` JSON/JS-object shapes for the same generic secret-key names (`token`, `api_key`, `secret`, `password`, `auth`, `session_id`, `sig`, `signature`, ...), redacting only the value while preserving the surrounding quoting style.

## Verification

Reproduced the gap and confirmed the fix with a standalone Node smoke test exercising the full `SECRET_VALUE_PATTERNS` list:

- `{"password":"hunter2","api_key":"sk_live_..."}` → both values now redacted, `username` (non-sensitive key) left untouched
- Nested JSON (`{"auth": {"token": "abc.def.ghi"}}`) → redacted
- Single-quoted JS-object style → redacted
- Pre-existing form/query encoding (`token=abc123&other=1`) → unaffected, still redacted
- Non-secret fields (`"note"`, `"count"`) → left untouched (no over-redaction)

Ran `prettier --check` on the changed file — passes. No existing automated test suite covers these pure-Node MCP servers (none exist yet for this directory), so verification was manual per above.

## Scope

Single, focused change to one redaction pattern list in one file. No API/schema changes, no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxzAXjtCi18cvumQSFHeCQ)_