### PR TITLE
fix: normalize semgrep_scan's cwe field to a bare CWE-id string

### DIFF
--- a/.codex/mcp-servers/semgrep/server.js
+++ b/.codex/mcp-servers/semgrep/server.js
@@ -6,6 +6,29 @@ const { runCommand, notFoundMessage } = require("../lib/run_tool.js");
 
 const SEVERITY_MAP = { ERROR: "high", WARNING: "medium", INFO: "low" };
 
+// Semgrep rule metadata carries `cwe` as an array of full description strings
+// (e.g. ["CWE-79: Improper Neutralization of Input During Web Page Generation
+// (XSS)"]) or occasionally a single such string -- never a bare id. Every
+// other scanner in this stack (bandit, program-analysis) and the findings
+// spine's own `cwe` field (mantis_findings) use a bare "CWE-89" id string, so
+// passing semgrep's raw metadata straight through breaks cross-tool
+// correlation/dedup on CWE. Extract the bare id(s) to match that shape.
+function normalizeCwe(raw) {
+  if (!raw) return null;
+  const list = Array.isArray(raw) ? raw : [raw];
+  const ids = [
+    ...new Set(
+      list
+        .map((entry) => {
+          const m = /CWE-\d+/i.exec(String(entry));
+          return m ? m[0].toUpperCase() : null;
+        })
+        .filter(Boolean),
+    ),
+  ];
+  return ids.length ? ids.join(", ") : null;
+}
+
 async function semgrepScan({ path: targetPath, config = "auto", rules }) {
   if (!targetPath) throw new Error("path is required");
 
@@ -44,7 +67,7 @@ async function semgrepScan({ path: targetPath, config = "auto", rules }) {
     end_line: r.end && r.end.line,
     severity: SEVERITY_MAP[r.extra && r.extra.severity] || "medium",
     message: r.extra && r.extra.message,
-    cwe: r.extra && r.extra.metadata && r.extra.metadata.cwe,
+    cwe: normalizeCwe(r.extra && r.extra.metadata && r.extra.metadata.cwe),
   }));
 
   return {


### PR DESCRIPTION
## Context

Part of the recurring 4h maintenance+testing routine (detection-improvement half).

## Gap this closes

`semgrep_scan` (`.codex/mcp-servers/semgrep/server.js`) passed `r.extra.metadata.cwe`
straight through into each candidate's `cwe` field. Semgrep's rule metadata carries
`cwe` as an **array of full description strings**, e.g.:

```json
["CWE-79: Improper Neutralization of Input During Web Page Generation (XSS)"]
```

Every other scanner in this stack normalizes to a bare id string instead:
- `bandit_scan` -> `` `CWE-${r.issue_cwe.id}` `` (e.g. `"CWE-89"`)
- `source_sink_scan` rules -> plain `"CWE-95"`/`"CWE-78"`/... strings

And the findings spine's own schema (`.codex/mcp-servers/findings/server.js`)
documents `cwe` as `'CWE id if known, e.g. "CWE-89"'` — a bare string, not an
array of descriptions.

So a `semgrep_scan` candidate's `cwe` value didn't match the shape every other
tool and the findings schema itself expect. That silently breaks cross-tool
CWE correlation/dedup (e.g. matching a semgrep XSS candidate against a
`js.dom.innerhtml` `source_sink_scan` candidate on shared CWE-79) and would
need reshaping by hand before it could be attached to a `finding_create` call
without violating the documented field type.

## What this PR adds

- `normalizeCwe(raw)` in `.codex/mcp-servers/semgrep/server.js`: accepts either
  the array form or a bare string, extracts bare `CWE-\d+` id(s) via regex,
  dedupes, and joins multiple matches with `", "`. Returns `null` when no CWE
  metadata is present.
- Wired into the `findings` mapper in place of the raw metadata passthrough.

No change to `severity` handling, output shape elsewhere, or the tool's
input schema.

## Verification

- `node --check .codex/mcp-servers/semgrep/server.js`
- `npx prettier --check .codex/mcp-servers/semgrep/server.js` — passes, no
  reformatting needed
- Manual functional test of `normalizeCwe` against representative semgrep
  metadata shapes (single description string, array of one, array of two
  distinct CWEs, `undefined`, empty array) — all produce bare
  `"CWE-NN"`/`"CWE-NN, CWE-MM"`/`null` as expected.

---

## Scan findings against the authorized target (`vulnerable-bounty-site.vercel.app`)

Not tied to this code change (no live-target work happened this run) — see
final session summary for the network-egress status, which is unchanged
from the prior two logged attempts (`origin/mantis-routine/2026-07-12-scan-log`,
`origin/scan-report-vulnerable-bounty-site-2026-07-13`, both still open/unmerged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GQuL9E3RyF6LTzMZYrwZUa)_