### PR TITLE
fix: normalize osv-scanner severity to the shared finding vocabulary

### DIFF
--- a/.codex/mcp-servers/osv-scanner/server.js
+++ b/.codex/mcp-servers/osv-scanner/server.js
@@ -4,6 +4,23 @@
 const { createServer } = require("../lib/mcp_stdio.js");
 const { runCommand, notFoundMessage } = require("../lib/run_tool.js");
 
+// OSV's database_specific.severity uses GHSA's vocabulary (upper-case, and
+// "MODERATE" instead of "MEDIUM"), which doesn't line up with the findings
+// spine's VALID_SEVERITIES (info/low/medium/high/critical). Passing it
+// through raw makes finding_create reject every OSV-sourced candidate.
+const SEVERITY_MAP = {
+  CRITICAL: "critical",
+  HIGH: "high",
+  MODERATE: "medium",
+  MEDIUM: "medium",
+  LOW: "low",
+};
+
+function normalizeSeverity(raw) {
+  if (!raw) return "medium";
+  return SEVERITY_MAP[String(raw).toUpperCase()] || "medium";
+}
+
 async function osvScan({ path: targetPath, offline = false }) {
   if (!targetPath) throw new Error("path is required");
 
@@ -48,9 +65,9 @@ async function osvScan({ path: targetPath, offline = false }) {
           version: pkg.package && pkg.package.version,
           vuln_id: vuln.id,
           summary: vuln.summary,
-          severity:
-            (vuln.database_specific && vuln.database_specific.severity) ||
-            "unknown",
+          severity: normalizeSeverity(
+            vuln.database_specific && vuln.database_specific.severity,
+          ),
           aliases: vuln.aliases || [],
         });
       }


### PR DESCRIPTION
## Context

Part of the recurring 4h maintenance+testing routine. This run's detection-pipeline improvement targets `.codex/mcp-servers/osv-scanner/server.js`.

## The gap

`osv_scan` mapped a finding's `severity` straight from OSV's `database_specific.severity`, which follows GHSA's vocabulary: upper-case strings, and `"MODERATE"` instead of `"MEDIUM"`. When missing, it fell back to the literal string `"unknown"`.

The findings spine (`.codex/mcp-servers/findings/server.js`) validates `severity` against a fixed, lower-case vocabulary: `["info", "low", "medium", "high", "critical"]`. Neither the raw GHSA casing (`"HIGH"`) nor the `"MODERATE"`/`"unknown"` values are members of that set, so `finding_create` throws `severity must be one of info, low, medium, high, critical` for essentially every OSV-sourced candidate that carries a severity at all. This is the same class of severity-vocabulary bug already fixed for `semgrep` and `trivy` (both have a `SEVERITY_MAP` + safe default), but `osv-scanner` still had the raw pass-through.

## What changed

Added a `SEVERITY_MAP` (mirroring the `trivy`/`semgrep` servers' existing pattern) plus a `normalizeSeverity()` helper:
- `CRITICAL → critical`, `HIGH → high`, `MODERATE`/`MEDIUM → medium`, `LOW → low`
- unknown/missing/unrecognized input defaults to `"medium"` (matching semgrep's/trivy's convention of a safe non-`"unknown"` default) instead of the previously-invalid `"unknown"` literal

## Testing

- `node -c .codex/mcp-servers/osv-scanner/server.js` — syntax OK
- `npx prettier --check .codex/mcp-servers/osv-scanner/server.js` — passes
- Manually exercised `normalizeSeverity` against `HIGH`, `MODERATE`, `low`, `CRITICAL`, `undefined`, `null`, `""`, and an unrecognized string — every case now resolves to a value in the findings spine's `VALID_SEVERITIES` set (previously `MODERATE`, `undefined`/`null`/`""`, and unrecognized strings all resolved to invalid values)
- No existing automated test suite covers `.codex/mcp-servers/*` (JS harness layer); none added, consistent with the sibling scanner servers

## Scope

Single-file, additive fix (new map + helper, one call-site change). No behavior change for the already-valid severities; only the previously-broken/invalid cases are affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_019F9XMrN6RuRxa6PDP5EHTN)_