### PR TITLE
fix: close secret-detection gap in findings-spine DLP backstop

### DIFF
--- a/.codex/mcp-servers/findings/server.js
+++ b/.codex/mcp-servers/findings/server.js
@@ -46,6 +46,11 @@ const SECRET_PATTERNS = [
   /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/, // Slack tokens
   /-----BEGIN [A-Z ]*PRIVATE KEY-----/, // PEM private keys
   /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/, // JWTs
+  /\b[A-Za-z0-9._%+-]+:[^@\s/]{6,}@/, // user:pass@ in URLs
+  // Generically-named secret-bearing params -- same shape http-audit already
+  // redacts; without this the findings spine's own DLP backstop misses the
+  // most common secret shape (a raw password/token/api key value).
+  /\b(?:token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=[^&\s]{6,}/i,
 ];
 
 function ensureDataDir() {


### PR DESCRIPTION
## What gap this closes

The findings spine (`.codex/mcp-servers/findings/server.js`) enforces a
DLP backstop (`scanForSecrets`) that refuses any `finding_create`/`finding_update`
payload containing what looks like a raw credential, per PRD section 9/11
("never raw secrets/tokens/cookies/full bodies").

The sibling `http-audit` evidence-pack redactor (`.codex/mcp-servers/http-audit/server.js`)
already redacts two secret shapes that the findings spine's own guard was
missing:

1. **Generically-named key=value secrets** — `password=...`, `api_key=...`,
   `token=...`, `secret=...`, etc. These have no distinctive character shape
   (unlike an AWS key or a JWT), so they need a name-based pattern, and
   `http-audit` already has one — the findings spine didn't.
2. **`user:pass@` credentials embedded in URLs.**

Without these, an agent could write a `candidate` finding whose evidence
text contains something like `password=hunter2live` or
`https://admin:S3cretPass!@internal.example.com/api`, and the findings
spine's guard would let it straight into the append-only event log
unredacted — exactly the outcome the guard exists to prevent. The two
DLP backstops (http-audit and findings) now match.

## Change

Added the same two regexes from `http-audit`'s `SECRET_VALUE_PATTERNS` to
`findings/server.js`'s `SECRET_PATTERNS` (adapted to boolean-test form, no
capture-based replacement needed here).

## Testing

- `node --check .codex/mcp-servers/findings/server.js` — syntax OK
- Manual regex test confirming: `password=...` and `user:pass@` strings
  are now caught; ordinary finding descriptions (e.g. "XSS in /search
  reflects q param unescaped, confirmed via alert(1)") still pass through
  unaffected — no new false positives on the case exercised.
- `npx prettier --check` on the changed file — passes.

No related bug report/enhancement request; found via routine review of the
`.codex/` detection/validation pipeline (recurring maintenance pass over the
mantis-* security tooling in this repo).


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9B8Frvhhit27BTDxTVLxQ)_