### PR TITLE
fix: normalize codeql_analyze's SARIF level to the shared severity vocabulary

### DIFF
--- a/.codex/mcp-servers/codeql/server.js
+++ b/.codex/mcp-servers/codeql/server.js
@@ -12,6 +12,23 @@ const CODEQL_NOT_FOUND = notFoundMessage(
   "download the CodeQL CLI bundle from github.com/github/codeql-cli-binaries and put it on PATH",
 );
 
+// SARIF's `level` vocabulary (error/warning/note/none, SARIF 2.1.0 §3.27.10)
+// is not the findings spine's severity vocabulary (info/low/medium/high/
+// critical, see .codex/mcp-servers/findings/server.js VALID_SEVERITIES).
+// Passing SARIF levels straight through made every codeql-sourced candidate
+// fail finding_create's severity check -- the same class of bug already
+// fixed for semgrep/bandit/trivy/osv-scanner's own SEVERITY_MAPs.
+const SARIF_LEVEL_SEVERITY_MAP = {
+  error: "high",
+  warning: "medium",
+  note: "low",
+  none: "info",
+};
+
+function normalizeSeverity(level) {
+  return SARIF_LEVEL_SEVERITY_MAP[level] || "medium";
+}
+
 async function codeqlCreateDatabase({
   source_root: sourceRoot,
   language,
@@ -99,7 +116,7 @@ async function codeqlAnalyze({
         result_.locations[0].physicalLocation;
       findings.push({
         rule_id: result_.ruleId,
-        level: result_.level || "warning",
+        severity: normalizeSeverity(result_.level),
         message: result_.message && result_.message.text,
         path: loc && loc.artifactLocation && loc.artifactLocation.uri,
         start_line: loc && loc.region && loc.region.startLine,
@@ -150,7 +167,7 @@ createServer({
     {
       name: "codeql_analyze",
       description:
-        "Run CodeQL query-suite analysis (default security-extended) against a database built by codeql_create_database. Emits `candidate` SAST findings with dataflow-backed rule IDs.",
+        "Run CodeQL query-suite analysis (default security-extended) against a database built by codeql_create_database. Emits `candidate` SAST findings with dataflow-backed rule IDs; `severity` is normalized from SARIF level (error/warning/note/none) to the shared info/low/medium/high/critical vocabulary used by finding_create.",
       inputSchema: {
         type: "object",
         properties: {


### PR DESCRIPTION
## Context

Part of the recurring 4h maintenance+testing routine. This run's detection-pipeline improvement targets `.codex/mcp-servers/codeql/server.js`.

## The gap

`codeql_analyze` mapped each SARIF result's `level` field straight through as `level: result_.level || "warning"`. SARIF's level vocabulary is `error`/`warning`/`note`/`none` (SARIF 2.1.0 §3.27.10).

The findings spine (`.codex/mcp-servers/findings/server.js`) validates `severity` against a fixed vocabulary: `["info", "low", "medium", "high", "critical"]`. None of SARIF's level values are members of that set, so any agent that took a codeql finding's `level` and passed it straight to `finding_create`'s `severity` would get `severity must be one of info, low, medium, high, critical` — every CodeQL-sourced candidate would fail registration. This is the same class of severity-vocabulary bug already fixed for `semgrep` and `trivy` (both carry a `SEVERITY_MAP`) and currently being fixed for `osv-scanner` in a sibling open PR — `codeql` was the one detector still doing a raw pass-through, and it also emitted the wrong field name (`level`, not `severity`) so callers copying the other scanners' shape would silently get `undefined`.

## What changed

Added a `SARIF_LEVEL_SEVERITY_MAP` + `normalizeSeverity()` helper (mirroring the `semgrep`/`trivy` servers' existing pattern):
- `error → high`, `warning → medium`, `note → low`, `none → info`
- unknown/missing input defaults to `"medium"` (matching the other scanners' safe-default convention)

Replaced the raw `level` field in each finding with the normalized `severity` field, and updated the `codeql_analyze` tool description to document the normalization.

## Testing

- `node -c .codex/mcp-servers/codeql/server.js` — syntax OK
- `npx prettier --check .codex/mcp-servers/codeql/server.js` — passes
- Manually exercised `normalizeSeverity` against `error`, `warning`, `note`, `none`, `undefined`, `null`, `""`, and an unrecognized string — every case now resolves to a value in the findings spine's `VALID_SEVERITIES` set (previously `error`/`warning`/`note`/`none` all resolved to invalid values, since none is a member of that set)
- No existing automated test suite covers `.codex/mcp-servers/*` (JS harness layer); none added, consistent with the sibling scanner-server fixes already open against this repo

## Scope

Single-file, additive fix (new map + helper, one call-site field rename). No behavior change beyond replacing the previously-invalid `level` value with a normalized, spine-valid `severity` value.

---
_Generated by Claude Code as part of the recurring mantis maintenance routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_0181oMzMfX4hmxfVzkQEFMaf)_