### PR TITLE
detect: add SQL injection sinks to the source-sink heuristic scanner

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -79,6 +79,20 @@ const RULES = [
     pattern: /\b(node-serialize|serialize\.unserialize)\s*\(/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.sql.query_template_literal",
+    pattern: /\.(query|execute)\s*\(\s*`[^`]*\$\{/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.sql.query_string_concat",
+    pattern: /\.(query|execute)\s*\(\s*(?:"[^"]*"|'[^']*')\s*\+/g,
+    cwe: "CWE-89",
+  },
 
   // Python
   {
@@ -129,6 +143,34 @@ const RULES = [
     pattern: /\byaml\.load\s*\((?!.*Loader=yaml\.SafeLoader)/g,
     cwe: "CWE-502",
   },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_fstring",
+    pattern: /\.execute\s*\(\s*f['"]/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_percent_format",
+    pattern: /\.execute\s*\(\s*(?:"[^"]*"|'[^']*')\s*%\s*/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_string_concat",
+    pattern: /\.execute\s*\(\s*(?:"[^"]*"|'[^']*')\s*\+/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.sql.execute_dot_format",
+    pattern: /\.execute\s*\(\s*(?:"[^"]*"|'[^']*')\s*\.format\s*\(/g,
+    cwe: "CWE-89",
+  },
 
   // Go
   {
@@ -151,6 +193,20 @@ const RULES = [
     id: "go.template.html",
     pattern: /\btemplate\.HTML\s*\(/g,
     cwe: "CWE-79",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.sql.query_sprintf",
+    pattern: /\.(Query|QueryRow|Exec)\s*\(\s*fmt\.Sprintf\s*\(/g,
+    cwe: "CWE-89",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.sql.query_string_concat",
+    pattern: /\.(Query|QueryRow|Exec)\s*\(\s*"[^"]*"\s*\+/g,
+    cwe: "CWE-89",
   },
 
   // Java


### PR DESCRIPTION
## What gap this closes

`source_sink_scan` (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) is the fast, dependency-free recall pass the Detector runs during Recon/Detect (see the `program-analysis` and `mantis-pipeline` skills). Auditing its rule table against the vulnerability classes Mantis is supposed to cover, **SQL injection had zero sink coverage** for JS, Python, and Go — despite CWE-89/SQLi being one of the core classes the pipeline is meant to catch (Java had only incidental, generic coverage via the pre-existing `java.statement.execute` rule). A target with an unparameterized query built via string concatenation or f-strings/template literals would currently produce no `candidate` from this scanner at all.

## What changed

Added CWE-89-tagged sink rules for the common unsafe-query-building shapes, mirroring the existing rule style (regex proxy, not a taint engine):

- **JS**: `.query()`/`.execute()` calls built from a template literal with `${...}` interpolation, or from string concatenation (`'...' + x`).
- **Python**: `cursor.execute(...)` built from an f-string, `%`-formatting, `.format()`, or string concatenation.
- **Go**: `.Query()`/`.QueryRow()`/`.Exec()` calls built via `fmt.Sprintf(...)` or string concatenation.

All new rules follow the existing convention: high recall, `cwe` tag set, no severity claimed (severity stays a Validate-stage decision per the findings lifecycle).

## Why the fix needed a second pass

My first draft used a shared `['"][^'"]*['"]` character class to match "some quoted string" generically. That silently breaks on any SQL string containing an apostrophe (e.g. `"... WHERE name = '" + name`), which is extremely common in real query text — the class excludes both quote characters, so it stops at the embedded `'` before reaching the real closing `"`. Since JS doesn't support backreferences inside character classes, I replaced it everywhere with an explicit `(?:"[^"]*"|'[^']*')` alternation, which correctly handles quoted strings containing the other quote character.

## Verification

No test harness exists yet for the `.codex/mcp-servers/*` JS servers (no `package.json`/jest in that tree), so I hand-verified with representative snippets per language, confirming:
- Each new sink rule fires on its target vulnerable pattern (template literal/f-string/`%`-format/`.format()`/string-concat).
- Parameterized (safe) query calls — e.g. `db.query('SELECT 1', [id])`, `cursor.execute("SELECT 1", (user_id,))` — correctly produce **no** match.

Also ran `prettier --write` on the changed file; no formatting changes were needed (matches existing style).

## Scope

Kept intentionally narrow: only the SQL injection sink gap, only in the existing rule table, no changes to the scanner engine, findings lifecycle, or other MCP servers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGapDRTQjkWkP5XeYEfHwT)_