### PR TITLE
fix: widen mantis_http_audit secret redaction to close JSON-body + provider-key gaps

### DIFF
--- a/.codex/mcp-servers/http-audit/server.js
+++ b/.codex/mcp-servers/http-audit/server.js
@@ -33,7 +33,16 @@ const SENSITIVE_HEADERS = new Set([
 const SECRET_VALUE_PATTERNS = [
   [/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]"],
   [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "[REDACTED_GH_TOKEN]"],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "[REDACTED_GH_TOKEN]"],
   [/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[REDACTED_SLACK_TOKEN]"],
+  [
+    /\bhttps:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]{6,}\/B[A-Za-z0-9]{6,}\/[A-Za-z0-9]{16,}\b/g,
+    "[REDACTED_SLACK_WEBHOOK]",
+  ],
+  [/\bAIza[0-9A-Za-z_-]{35}\b/g, "[REDACTED_GOOGLE_API_KEY]"],
+  [/\b(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{16,}\b/g, "[REDACTED_STRIPE_KEY]"],
+  [/\bnpm_[A-Za-z0-9]{36}\b/g, "[REDACTED_NPM_TOKEN]"],
+  [/\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}\b/g, "[REDACTED_SENDGRID_KEY]"],
   [
     /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
     "[REDACTED_JWT]",
@@ -48,6 +57,14 @@ const SECRET_VALUE_PATTERNS = [
   [
     /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
     (_match, name) => `${name}=[REDACTED]`,
+  ],
+  // Same generically-named secrets, but shaped as a JSON body field
+  // (`"password": "hunter2"`) instead of a query/form param -- the pattern
+  // above only matches `key=value`, so a JSON request/response body sailed
+  // through unredacted.
+  [
+    /"(token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|secret|password|passwd|session[_-]?id|sig|signature)"\s*:\s*"([^"]*)"/gi,
+    (_match, name) => `"${name}":"[REDACTED]"`,
   ],
 ];
 
@@ -159,30 +176,34 @@ function auditExchange({ request, response }) {
   return pack;
 }
 
-createServer({
-  name: "mantis-http-audit",
-  version: "0.1.0",
-  tools: [
-    {
-      name: "http_audit",
-      description:
-        "Turn a raw HTTP request and/or response into a bounded, redacted evidence pack with a stable request-ref hash. Use during Validate/DAST to attach reproducible HTTP evidence to a finding WITHOUT storing raw secrets, cookies, or full bodies. Pure function; no network is made -- you pass in captured text.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          request: {
-            type: "string",
-            description:
-              "Raw HTTP request text (request line + headers + optional body).",
-          },
-          response: {
-            type: "string",
-            description:
-              "Raw HTTP response text (status line + headers + optional body).",
+if (require.main === module) {
+  createServer({
+    name: "mantis-http-audit",
+    version: "0.1.0",
+    tools: [
+      {
+        name: "http_audit",
+        description:
+          "Turn a raw HTTP request and/or response into a bounded, redacted evidence pack with a stable request-ref hash. Use during Validate/DAST to attach reproducible HTTP evidence to a finding WITHOUT storing raw secrets, cookies, or full bodies. Pure function; no network is made -- you pass in captured text.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            request: {
+              type: "string",
+              description:
+                "Raw HTTP request text (request line + headers + optional body).",
+            },
+            response: {
+              type: "string",
+              description:
+                "Raw HTTP response text (status line + headers + optional body).",
+            },
           },
         },
+        handler: auditExchange,
       },
-      handler: auditExchange,
-    },
-  ],
-});
+    ],
+  });
+}
+
+module.exports = { redactValue, auditExchange, SECRET_VALUE_PATTERNS };

--- a/.codex/mcp-servers/http-audit/server.test.js
+++ b/.codex/mcp-servers/http-audit/server.test.js
@@ -1,0 +1,130 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { redactValue, auditExchange } = require("./server.js");
+
+test("redactValue strips AWS access key ids", () => {
+  const out = redactValue("key is AKIAABCDEFGHIJKLMNOP done");
+  assert.equal(out, "key is [REDACTED_AWS_KEY] done");
+});
+
+test("redactValue strips classic and fine-grained GitHub tokens", () => {
+  assert.equal(redactValue("ghp_" + "a".repeat(36)), "[REDACTED_GH_TOKEN]");
+  assert.equal(
+    redactValue("github_pat_" + "a".repeat(22) + "_" + "b".repeat(59)),
+    "[REDACTED_GH_TOKEN]",
+  );
+});
+
+test("redactValue strips Slack tokens and incoming webhook URLs", () => {
+  assert.equal(
+    redactValue("xoxb-123456789012-abcdefghij"),
+    "[REDACTED_SLACK_TOKEN]",
+  );
+  const fakeWebhook =
+    "https://hooks.slack.com/services/" +
+    "T00000000" +
+    "/" +
+    "B00000000" +
+    "/" +
+    "z".repeat(24);
+  assert.equal(redactValue(fakeWebhook), "[REDACTED_SLACK_WEBHOOK]");
+});
+
+test("redactValue strips Google API keys", () => {
+  const key = "AIza" + "S".repeat(35);
+  assert.equal(
+    redactValue(`x-goog-key: ${key}`),
+    `x-goog-key: [REDACTED_GOOGLE_API_KEY]`,
+  );
+});
+
+test("redactValue strips Stripe live/test secret keys", () => {
+  assert.equal(
+    redactValue("sk_live_" + "a".repeat(24)),
+    "[REDACTED_STRIPE_KEY]",
+  );
+  assert.equal(
+    redactValue("rk_test_" + "a".repeat(24)),
+    "[REDACTED_STRIPE_KEY]",
+  );
+});
+
+test("redactValue strips npm and SendGrid tokens", () => {
+  assert.equal(redactValue("npm_" + "a".repeat(36)), "[REDACTED_NPM_TOKEN]");
+  assert.equal(
+    redactValue("SG." + "a".repeat(22) + "." + "b".repeat(43)),
+    "[REDACTED_SENDGRID_KEY]",
+  );
+});
+
+test("redactValue strips JWTs and PEM private keys", () => {
+  const jwt =
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dQw4w9WgXcQ_abc123XYZ";
+  assert.equal(redactValue(jwt), "[REDACTED_JWT]");
+
+  const pem =
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJ...\n-----END RSA PRIVATE KEY-----";
+  assert.equal(redactValue(pem), "[REDACTED_PRIVATE_KEY]");
+});
+
+test("redactValue strips userinfo credentials embedded in URLs", () => {
+  assert.equal(
+    redactValue("postgres://admin:hunter2secret@db.internal:5432/app"),
+    "postgres://[REDACTED_USERINFO]@db.internal:5432/app",
+  );
+});
+
+test("redactValue strips generically-named query/form secret params", () => {
+  assert.equal(
+    redactValue("/reset?token=abc123&next=/home"),
+    "/reset?token=[REDACTED]&next=/home",
+  );
+  assert.equal(
+    redactValue("password=hunter2&remember=1"),
+    "password=[REDACTED]&remember=1",
+  );
+});
+
+test("redactValue strips the same generically-named secrets in a JSON body", () => {
+  const body = '{"username":"alice","password":"hunter2","ok":true}';
+  assert.equal(
+    redactValue(body),
+    '{"username":"alice","password":"[REDACTED]","ok":true}',
+  );
+
+  const tokenBody = '{"access_token": "abc.def-123", "expires_in": 3600}';
+  assert.equal(
+    redactValue(tokenBody),
+    '{"access_token":"[REDACTED]", "expires_in": 3600}',
+  );
+});
+
+test("redactValue leaves ordinary, non-secret text untouched", () => {
+  const text = "GET /api/widgets?page=2&sort=name HTTP/1.1";
+  assert.equal(redactValue(text), text);
+});
+
+test("auditExchange redacts sensitive headers and JSON-body secrets end to end", () => {
+  const request = [
+    "POST /login HTTP/1.1",
+    "Host: example.test",
+    "Authorization: Bearer sometoken",
+    "Cookie: session=abc123",
+    "Content-Type: application/json",
+    "",
+    '{"username":"alice","password":"hunter2"}',
+  ].join("\r\n");
+
+  const pack = auditExchange({ request });
+  assert.deepEqual(pack.request.redacted_headers, ["Authorization", "Cookie"]);
+  assert.ok(
+    pack.request.headers.every(
+      (h) => h.name !== "Authorization" || h.value === "[REDACTED]",
+    ),
+  );
+  assert.ok(!pack.request.body.preview.includes("hunter2"));
+  assert.ok(pack.request.body.preview.includes('"password":"[REDACTED]"'));
+  assert.match(pack.request.request_ref, /^req-[0-9a-f]{16}$/);
+});

--- a/.codex/skills/http-evidence/SKILL.md
+++ b/.codex/skills/http-evidence/SKILL.md
@@ -7,7 +7,7 @@ Use `http_audit` (mantis_http_audit MCP server) whenever you have a captured HTT
 
 Why go through it instead of pasting the raw exchange into the finding:
 
-- It strips secret-bearing headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, CSRF tokens, ...) and inline secrets (AWS keys, GitHub/Slack tokens, JWTs, private keys, `user:pass@` in URLs). Raw secrets must never land in a finding, artifact, report, or prompt (PRD section 9/11).
+- It strips secret-bearing headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, CSRF tokens, ...) and inline secrets (AWS keys, GitHub/Slack tokens, Slack webhook URLs, Google/Stripe/npm/SendGrid API keys, JWTs, private keys, `user:pass@` in URLs, and generically-named secret fields like `password`/`token`/`api_key` in both query/form params and JSON bodies). Raw secrets must never land in a finding, artifact, report, or prompt (PRD section 9/11).
 - It bounds the body: full bodies are hashed and previewed (first 512 bytes), never stored whole.
 - The `request_ref` is a stable hash of the exchange, so the same request always maps to the same id -- use it to cross-reference and dedup evidence across findings.
 


### PR DESCRIPTION
## Summary

Scheduled maintenance run — one incremental detection/evidence-quality fix in the `mantis_http_audit` MCP server (`.codex/mcp-servers/http-audit/server.js`).

**The gap:** `mantis_http_audit` is the tool every Mantis stage is supposed to route captured HTTP evidence through so that raw secrets never land in a finding, report, or prompt (PRD section 9/11 invariant). Its generically-named-secret pattern (`token`, `password`, `api_key`, `secret`, ...) only matched query/form-encoded `key=value` pairs. The exact same field shaped as a JSON body member — `"password": "hunter2"` — is arguably the more common shape in modern JSON APIs, and it sailed through completely unredacted. That's a real secret-leak path in a tool whose entire job is to guarantee that doesn't happen, and it directly weakens coverage of the "exposed secrets" vulnerability class this run's scan is also checking for.

**The fix:**
- Add a JSON-body variant of the generic secret-field pattern (`"password":"[REDACTED]"` instead of leaking the value).
- Round out shape-based coverage for provider key formats the existing list missed: GitHub fine-grained PATs (`github_pat_...`, the classic `ghp_...` regex doesn't match the newer prefix), Slack incoming webhook URLs, Google API keys (`AIza...`), Stripe live/test secret keys (`sk_live_...`/`rk_test_...`), npm tokens (`npm_...`), and SendGrid keys (`SG....`).
- Guard the MCP stdio server startup behind `require.main === module` and export the pure redaction functions (`redactValue`, `auditExchange`) so they're unit-testable without spinning up the stdio transport — this server previously had zero test coverage despite doing security-critical redaction.
- Add `server.test.js` (Node's built-in `node:test`/`assert`, zero new deps, consistent with the server's "pure Node, zero deps" design) — 12 cases covering every existing and new pattern individually plus an end-to-end `auditExchange` regression check that a JSON-body password and an `Authorization`/`Cookie` header are both redacted from a single captured exchange.
- Updated the `http-evidence` skill doc to describe the widened coverage so agents relying on it have an accurate picture of what's actually redacted.

Scope kept intentionally small: this is a targeted pattern-list + test-coverage fix to one existing MCP server, not a rewrite. No new dependencies, no new servers.

## Verification

```
$ node --test .codex/mcp-servers/http-audit/server.test.js
# tests 12
# pass 12
# fail 0

$ printf '{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n' | node .codex/mcp-servers/http-audit/server.js
# still starts and lists the http_audit tool correctly (require.main guard doesn't change runtime behavior)

$ npx prettier --check .codex/mcp-servers/http-audit/server.js .codex/mcp-servers/http-audit/server.test.js
# clean
```

## Test plan

- [x] `node --test .codex/mcp-servers/http-audit/server.test.js` passes (12/12)
- [x] Server still starts and responds to `tools/list` under the actual MCP stdio transport (unchanged behavior for the real entry point)
- [x] `prettier --check` clean on changed files
- [ ] Reviewer: confirm the new JSON-body regex doesn't over-redact adjacent non-secret JSON fields (see `server.test.js` JSON-body test case for the exact before/after)

---

## Scan summary (part 2 of this run's routine)

Also ran the authorized discovery-only scan against `https://vulnerable-bounty-site.vercel.app` per this run's instructions. That work isn't tied to a code change, so its findings are reported in the run's final chat summary rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PehwXFCjgEsyjhNAuh2o8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01PehwXFCjgEsyjhNAuh2o8d)_