### PR TITLE
fix: redact JSON-shaped secret fields in http-audit evidence packs

### DIFF
--- a/.codex/mcp-servers/http-audit/server.js
+++ b/.codex/mcp-servers/http-audit/server.js
@@ -49,6 +49,14 @@ const SECRET_VALUE_PATTERNS = [
     /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
     (_match, name) => `${name}=[REDACTED]`,
   ],
+  // Same generically-named secret fields, but in JSON body shape
+  // (`"password": "value"`) rather than query/form shape -- the overwhelming
+  // majority of modern API request/response bodies are JSON, and without this
+  // the query/form pattern above never fires on them.
+  [
+    /"(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)"\s*:\s*"[^"]*"/gi,
+    (_match, name) => `"${name}":"[REDACTED]"`,
+  ],
 ];
 
 const MAX_BODY_PREVIEW = 512;


### PR DESCRIPTION
## What gap this closes

`mantis_http_audit` (`.codex/mcp-servers/http-audit/server.js`) is the pure-Node evidence-redaction tool the Validate/DAST stage uses to turn a captured HTTP request/response into a bounded, redacted evidence pack before it's attached to a finding. Its generic "secret-named field" redaction pass only matched **query/form-encoded** pairs:

```
/\b(token|api[_-]?key|...|signature)=([^&\s]+)/gi
```

That pattern never fires on **JSON bodies** (`"password": "..."`, `"api_key": "..."`), which is the dominant content type for modern API request/response bodies. Practically: capture a JSON API exchange containing a `password`/`api_key`/`refresh_token`/etc. field, run it through `http_audit`, and that value sails through into the 512-byte body preview completely unredacted — the exact kind of secret leak this tool exists to prevent (PRD section 9/11: "never raw secrets/tokens/cookies/full bodies" in findings/evidence).

## The fix

Added a second pattern that matches the same generically-named secret fields in JSON key/value shape (`"password":"value"` → `"password":"[REDACTED]"`), alongside the existing query-string pattern. Shape-based patterns (AWS keys, GitHub/Slack tokens, JWTs, private keys) are unaffected since they match the value itself regardless of surrounding syntax.

## Why it's safe / scoped

- Pure regex addition, no behavior change to existing redaction paths.
- Verified manually (no existing test harness for these MCP servers):
  - JSON body with `password`/`api_key`/nested `refresh_token` fields → all three now redacted.
  - Existing form-encoded case (`user=alice&password=hunter2`) still redacts correctly.
  - A JSON body with no secret-named fields is passed through byte-for-byte unchanged (no false positives introduced).
- `prettier --check` passes on the changed file.

## Test plan

- [x] Manual regex verification (JSON + form-encoded cases, see PR discussion/commit)
- [x] `prettier --check .codex/mcp-servers/http-audit/server.js`
- [ ] Add an automated unit test for this server once a test harness exists for `.codex/mcp-servers/*` (none currently does)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C9o3xhVTVXXt56EdFPcRCs)_