### PR TITLE
detect: add open-redirect (CWE-601) sink coverage to source_sink_scan

### DIFF
--- a/.codex/mcp-servers/program-analysis/source_sink_rules.js
+++ b/.codex/mcp-servers/program-analysis/source_sink_rules.js
@@ -188,6 +188,53 @@ const RULES = [
     pattern: /\bstatement\.execute(Query|Update)?\s*\(/gi,
     cwe: "CWE-89",
   },
+
+  // Open Redirect (CWE-601) -- redirecting to an attacker-controlled URL.
+  // `mantis-pipeline`'s Detect stage names SQLi/XSS/SSRF/deserialization
+  // explicitly but this class had zero sink coverage across every language
+  // already represented here, despite being a routine bug-bounty finding.
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.express.redirect",
+    pattern: /\bres\.redirect\s*\(/g,
+    cwe: "CWE-601",
+  },
+  {
+    lang: "js",
+    kind: "sink",
+    id: "js.http.location_header",
+    pattern: /\bsetHeader\s*\(\s*["']Location["']/gi,
+    cwe: "CWE-601",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.flask.redirect",
+    pattern: /\bredirect\s*\(/g,
+    cwe: "CWE-601",
+  },
+  {
+    lang: "py",
+    kind: "sink",
+    id: "py.django.http_response_redirect",
+    pattern: /\bHttpResponseRedirect\s*\(/g,
+    cwe: "CWE-601",
+  },
+  {
+    lang: "go",
+    kind: "sink",
+    id: "go.http.redirect",
+    pattern: /\bhttp\.Redirect\s*\(/g,
+    cwe: "CWE-601",
+  },
+  {
+    lang: "java",
+    kind: "sink",
+    id: "java.response.send_redirect",
+    pattern: /\bsendRedirect\s*\(/g,
+    cwe: "CWE-601",
+  },
 ];
 
 module.exports = { RULES };


### PR DESCRIPTION
## What gap this closes

`source_sink_scan` (`.codex/mcp-servers/program-analysis/source_sink_rules.js`) had sink coverage for command injection, XSS, deserialization, and eval-family sinks across JS/Python/Go/Java — but **zero sink patterns for open redirect (CWE-601)** in any language, despite it being one of the most routinely-reported classes in web-app bug-bounty scope (the kind of target this tool is built to scan).

## What changed

Added one additive sink rule per framework redirect primitive, in the languages the heuristic already covers — no existing rules touched:

- **JS**: `res.redirect(...)` (Express), `setHeader("Location", ...)`
- **Python**: `redirect(...)` (Flask), `HttpResponseRedirect(...)` (Django)
- **Go**: `http.Redirect(...)`
- **Java**: `sendRedirect(...)`

All tagged `cwe: "CWE-601"`, `kind: "sink"`, consistent with the existing rule shape.

## Testing

No test harness covers this pure-data rules file (same as prior rule-coverage PRs in this repo). Verified manually:
- `node --check` on the modified file — syntax OK.
- Loaded `RULES` and regex-tested each new rule against a positive sample (e.g. `res.redirect(req.query.url)`) — all 6 match — and against negative-control strings (unrelated calls/log lines) — no false matches.
- Ran the actual `source_sink_scan` logic (file walk + regex extraction, same code path `server.js` uses) against a small Express fixture (`req.query.next` source → `res.redirect(next)` sink) — both source and new sink are correctly tagged on their respective lines.
- `npx prettier --check` on the changed file — passes, no format diff needed.

## Scope

Single file, additive only (`+47` lines), no existing rule patterns modified. This is a Detect-stage heuristic only — it produces `candidate`s for the Recon/Detect stage; reachability/validation still runs downstream per the `mantis-pipeline` skill before anything is treated as a real finding.

---
_Part of the recurring 4h maintenance+testing routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lt4XPsuQ9bX481z43izBL1)_