### PR TITLE
fix: close secret-DLP coverage gap between findings guard and http-audit redactor

### DIFF
--- a/.codex/mcp-servers/findings/server.js
+++ b/.codex/mcp-servers/findings/server.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
 const { createServer } = require("../lib/mcp_stdio.js");
+const { containsSecret } = require("../lib/secret_patterns.js");
 
 /**
  * Mantis findings service -- the tool-owned findings spine (PRD section 9,
@@ -37,17 +38,6 @@ const STATUS_TRANSITIONS = {
 const VALID_STATUSES = Object.keys(STATUS_TRANSITIONS);
 const VALID_SEVERITIES = ["info", "low", "medium", "high", "critical"];
 
-// Cheap secret-shaped-string guard so raw credentials never land in a finding
-// or evidence blob (PRD section 9 "never raw secrets/tokens/cookies/full
-// bodies", section 11 secrets/DLP). This is a backstop, not a full DLP engine.
-const SECRET_PATTERNS = [
-  /\bAKIA[0-9A-Z]{16}\b/, // AWS access key id
-  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/, // GitHub tokens
-  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/, // Slack tokens
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----/, // PEM private keys
-  /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/, // JWTs
-];
-
 function ensureDataDir() {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
@@ -60,10 +50,12 @@ function newId() {
   return `MANTIS-${crypto.randomBytes(5).toString("hex")}`;
 }
 
-function scanForSecrets(value) {
-  const hay = typeof value === "string" ? value : JSON.stringify(value ?? "");
-  return SECRET_PATTERNS.some((re) => re.test(hay));
-}
+// Cheap secret-shaped-string guard so raw credentials never land in a finding
+// or evidence blob (PRD section 9 "never raw secrets/tokens/cookies/full
+// bodies", section 11 secrets/DLP). This is a backstop, not a full DLP
+// engine -- pattern list lives in lib/secret_patterns.js, shared with the
+// http-audit evidence redactor so the two guards can't drift apart.
+const scanForSecrets = containsSecret;
 
 function appendEvent(event) {
   ensureDataDir();

--- a/.codex/mcp-servers/http-audit/server.js
+++ b/.codex/mcp-servers/http-audit/server.js
@@ -3,6 +3,10 @@
 
 const crypto = require("node:crypto");
 const { createServer } = require("../lib/mcp_stdio.js");
+const {
+  SECRET_PATTERNS,
+  globalPatterns,
+} = require("../lib/secret_patterns.js");
 
 /**
  * Mantis HTTP-audit + request-refs (PRD section 6 "Proxy / traffic:
@@ -29,27 +33,13 @@ const SENSITIVE_HEADERS = new Set([
   "x-xsrf-token",
 ]);
 
-// Inline secret shapes that can appear anywhere in a body/URL.
-const SECRET_VALUE_PATTERNS = [
-  [/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]"],
-  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "[REDACTED_GH_TOKEN]"],
-  [/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[REDACTED_SLACK_TOKEN]"],
-  [
-    /\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
-    "[REDACTED_JWT]",
-  ],
-  [
-    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
-    "[REDACTED_PRIVATE_KEY]",
-  ],
-  [/\b[A-Za-z0-9._%+-]+:[^@\s/]{6,}@/g, "[REDACTED_USERINFO]@"], // user:pass@ in URLs
-  // Generically-named secret-bearing query/form params -- shape-based patterns above
-  // can't catch these since the secret value itself has no distinctive shape.
-  [
-    /\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\s]+)/gi,
-    (_match, name) => `${name}=[REDACTED]`,
-  ],
-];
+// Inline secret shapes that can appear anywhere in a body/URL. Pattern list
+// lives in lib/secret_patterns.js, shared with the findings-spine DLP guard
+// so the two never drift out of sync with each other.
+const SECRET_VALUE_PATTERNS = globalPatterns().map((re, i) => [
+  re,
+  SECRET_PATTERNS[i].replacement,
+]);
 
 const MAX_BODY_PREVIEW = 512;
 

--- a/.codex/mcp-servers/lib/secret_patterns.js
+++ b/.codex/mcp-servers/lib/secret_patterns.js
@@ -1,0 +1,104 @@
+"use strict";
+
+/**
+ * Canonical secret-shape patterns, shared by every server that must keep a
+ * raw credential from surviving into a finding or an evidence pack (PRD
+ * section 9/11 secrets/DLP). Single source of truth so the http-audit
+ * redactor and the findings-spine DLP guard can't silently drift out of sync
+ * -- they had: http-audit already redacted JWTs, `user:pass@` URL userinfo,
+ * and generically-named `token=`/`password=`-style params that the
+ * findings/server.js `scanForSecrets` guard did not know about, so a finding
+ * payload carrying one of those would sail past the "never raw secrets"
+ * refusal even though the evidence-pack redactor would have caught it.
+ *
+ * Every `source` is written without the "g" flag. Callers needing a global
+ * match (redaction) build their own fresh RegExp per call via
+ * `globalPatterns()` so a reused global RegExp's `lastIndex` can never leak a
+ * false negative into `.test()`-based detection (the classic global-regex
+ * `.test()` statefulness bug).
+ */
+const SECRET_PATTERNS = [
+  {
+    name: "aws_access_key_id",
+    source: "\\bAKIA[0-9A-Z]{16}\\b",
+    replacement: "[REDACTED_AWS_KEY]",
+  },
+  {
+    name: "github_token",
+    source: "\\bgh[pousr]_[A-Za-z0-9]{20,}\\b",
+    replacement: "[REDACTED_GH_TOKEN]",
+  },
+  {
+    name: "slack_token",
+    source: "\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b",
+    replacement: "[REDACTED_SLACK_TOKEN]",
+  },
+  {
+    name: "pem_private_key",
+    source:
+      "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----",
+    replacement: "[REDACTED_PRIVATE_KEY]",
+  },
+  {
+    name: "jwt",
+    source:
+      "\\bey[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b",
+    replacement: "[REDACTED_JWT]",
+  },
+  {
+    name: "google_api_key",
+    source: "\\bAIza[0-9A-Za-z_-]{35}\\b",
+    replacement: "[REDACTED_GOOGLE_API_KEY]",
+  },
+  {
+    name: "stripe_live_key",
+    source: "\\b(?:sk|rk)_live_[0-9a-zA-Z]{16,}\\b",
+    replacement: "[REDACTED_STRIPE_KEY]",
+  },
+  {
+    name: "npm_token",
+    source: "\\bnpm_[A-Za-z0-9]{36}\\b",
+    replacement: "[REDACTED_NPM_TOKEN]",
+  },
+  {
+    name: "sendgrid_key",
+    source: "\\bSG\\.[A-Za-z0-9_-]{16,}\\.[A-Za-z0-9_-]{16,}\\b",
+    replacement: "[REDACTED_SENDGRID_KEY]",
+  },
+  {
+    name: "url_userinfo",
+    source: "\\b[A-Za-z0-9._%+-]+:[^@\\s/]{6,}@",
+    replacement: "[REDACTED_USERINFO]@",
+  },
+  {
+    name: "named_secret_param",
+    source:
+      "\\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|auth|session[_-]?id|sig|signature)=([^&\\s]+)",
+    flags: "i",
+    replacement: (_match, paramName) => `${paramName}=[REDACTED]`,
+  },
+];
+
+// Fresh, non-global RegExp per pattern -- safe to `.test()` repeatedly since
+// there is no "g"/"y" flag `lastIndex` to carry state between calls.
+function detectPatterns() {
+  return SECRET_PATTERNS.map((p) => new RegExp(p.source, p.flags || ""));
+}
+
+// Fresh, global RegExp per pattern -- for `.replace()`-based redaction of
+// every occurrence, not just the first.
+function globalPatterns() {
+  return SECRET_PATTERNS.map((p) => new RegExp(p.source, `g${p.flags || ""}`));
+}
+
+function containsSecret(value) {
+  const hay = typeof value === "string" ? value : JSON.stringify(value ?? "");
+  return detectPatterns().some((re) => re.test(hay));
+}
+
+module.exports = {
+  SECRET_PATTERNS,
+  detectPatterns,
+  globalPatterns,
+  containsSecret,
+};


### PR DESCRIPTION
## What gap this closes

`.codex/mcp-servers/findings/server.js` and `.codex/mcp-servers/http-audit/server.js` each kept their own independent copy of the "does this look like a raw secret" pattern list. They had already drifted:

- `findings/server.js`'s `scanForSecrets()` — the backstop that refuses any `finding_create`/`finding_update` payload shaped like a raw credential (PRD section 9/11 secrets/DLP) — was missing two shapes that `http-audit`'s evidence-pack redactor already handled: `user:pass@` URL userinfo, and generically-named `token=`/`password=`/`secret=`-style query/form params.
- Net effect: a finding payload carrying a leaked credential in one of those two shapes would sail past the "never raw secrets" refusal in the findings spine, even though the same credential would have been redacted if it had gone through `http_audit` first. That's a real detection/DLP inconsistency, not just style debt.

## What changed

- Added `.codex/mcp-servers/lib/secret_patterns.js` as the single source of truth for secret-shape patterns, exporting:
  - `detectPatterns()` — fresh non-global `RegExp`s per call, safe for repeated `.test()` (avoids the classic global-regex `lastIndex` statefulness bug)
  - `globalPatterns()` — fresh global `RegExp`s per call, for `.replace()`-based redaction
  - `containsSecret(value)` — the boolean guard
- `findings/server.js` now uses `containsSecret` from the shared module instead of its own pattern list.
- `http-audit/server.js` now builds its redaction table from the shared module's patterns + per-pattern `replacement` instead of its own pattern list.
- Extended the shared list with a few more common secret shapes both guards were missing entirely: Google API keys (`AIza...`), Stripe live keys (`sk_live_`/`rk_live_`), npm tokens (`npm_...`), SendGrid keys (`SG.x.y`).

Net: the two guards can no longer independently drift apart, and both now catch a broader set of real-world secret shapes.

## Why

The Mantis findings spine's stated invariant is "never raw secrets/tokens/cookies/full bodies" land in a finding (PRD section 9/11). Two independently-maintained pattern lists enforcing that same invariant is exactly how gaps like this open up over time — the fix is structural (one shared source of truth), not just adding more patterns.

## Testing

No JS test harness exists yet for the `.codex/mcp-servers/*` servers, so I exercised the real code paths directly:

- `node -c` syntax-checked all three changed/added files.
- `prettier --check` passes on all three files (repo's `.prettierrc.toml`).
- Wrote a standalone Node script exercising `containsSecret()` against 13 cases (7 previously-covered secret shapes, 4 newly-added shapes, 2 benign strings) — all pass.
- Drove both MCP servers end-to-end over their real stdio JSON-RPC protocol (not mocked):
  - `findings/server.js`: a `finding_create` call containing a Google API key is now correctly **refused**; a normal XSS finding is still accepted and persisted.
  - `http-audit/server.js`: an HTTP request with `?token=...` and an `Authorization: Bearer sk_live_...` header comes back with both redacted in the evidence pack.
- Confirmed `.codex/findings/` is gitignored and removed the scratch event log created by the manual server test before committing.

## Scan findings (authorized target)

Not tied to this PR — see the run's final summary / `reports/` for the discovery-only scan against the authorized target for this run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeRoFRZXnxWYNaT6SXmgi1)_